### PR TITLE
chall-1/fix wagmi cache issue on `deploy --reset`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Before you begin, you need to install the following tools:
 - Yarn ([v1](https://classic.yarnpkg.com/en/docs/install/) or [v2+](https://yarnpkg.com/getting-started/install))
 - [Git](https://git-scm.com/downloads)
 
-Then run:
+Then download the challenge to your computer and install dependencies by running:
 
 ```sh
 git clone https://github.com/scaffold-eth/se-2-challenges.git challenge-1-decentralized-staking
@@ -69,11 +69,11 @@ uint256 public constant threshold = 1 ether;
 
 ![debugContracts](https://github.com/scaffold-eth/se-2-challenges/assets/55535804/1a888e31-a79b-49ef-9848-357c5cee445a)
 
-💸 Need more funds from the faucet? Click on _"Grab funds from faucet"_, or use the Faucet feature at the bottom left of the page to get as much as you need!
+> 💸 Need more funds from the faucet? Click on _"Grab funds from faucet"_, or use the Faucet feature at the bottom left of the page to get as much as you need!
 
 ![Faucet](https://github.com/scaffold-eth/se-2-challenges/assets/55535804/e82e3100-20fb-4886-a6bf-4113c3729f53)
 
-✏ Need to troubleshoot your code? If you import `hardhat/console.sol` to your contract, you can call `console.log()` right in your Solidity code. The output will appear in your `yarn chain` terminal.
+> ✏ Need to troubleshoot your code? If you import `hardhat/console.sol` to your contract, you can call `console.log()` right in your Solidity code. The output will appear in your `yarn chain` terminal.
 
 #### 🥅 Goals
 
@@ -87,6 +87,8 @@ uint256 public constant threshold = 1 ether;
 
 ### Checkpoint 3: 🔬 State Machine / Timing ⏱
 
+#### State Machine
+
 > ⚙️ Think of your smart contract like a _state machine_. First, there is a **stake** period. Then, if you have gathered the `threshold` worth of ETH, there is a **success** state. Or, we go into a **withdraw** state to let users withdraw their funds.
 
 Set a `deadline` of `block.timestamp + 30 seconds`
@@ -99,26 +101,28 @@ uint256 public deadline = block.timestamp + 30 seconds;
 
 > 👩‍💻 Write your `execute()` function and test it with the `Debug Contracts` tab
 
-> Check the ExampleExternalContract.sol for the bool you can use to test if it has been completed or not. But do not edit the ExampleExternalContract.sol as it can slow the auto grading.
+> Check the `ExampleExternalContract.sol` for the bool you can use to test if it has been completed or not. But do not edit the `ExampleExternalContract.sol` as it can slow the auto grading.
 
 If the `address(this).balance` of the contract is over the `threshold` by the `deadline`, you will want to call: `exampleExternalContract.complete{value: address(this).balance}()`
 
 If the balance is less than the `threshold`, you want to set a `openForWithdraw` bool to `true` and allow users to `withdraw()` their funds.
 
-(You'll have 30 seconds after deploying until the deadline is reached, you can adjust this in the contract.)
+#### Timing
+
+You'll have 30 seconds after deploying until the deadline is reached, you can adjust this in the contract.
 
 > 👩‍💻 Create a `timeLeft()` function including `public view returns (uint256)` that returns how much time is left.
 
-⚠️ Be careful! if `block.timestamp >= deadline` you want to `return 0;`
+⚠️ Be careful! If `block.timestamp >= deadline` you want to `return 0;`
 
 ⏳ _"Time Left"_ will only update if a transaction occurs. You can see the time update by getting funds from the faucet button in navbar just to trigger a new block.
 
-If the `Staker UI` tab _"Time Left"_ does not update correctly when a transaction occurs, try switching to other tab and come back to it.
+> 👩‍💻 You can call `yarn deploy --reset` any time you want a fresh contract, it will get re-deployed even if there are no changes on it.  
+> You may need it when you want to reload the _"Time Left"_ for your tests.
+
+If the `Staker UI` tab is open when you `yarn deploy --reset`, _"Time Left"_ and the rest of the contract values might not update after a transaction occurs. You may need to refresh the browser or try switching to other tab and come back to it.
 
 ![stakerUI](https://github.com/scaffold-eth/se-2-challenges/assets/55535804/7d85badb-3ea3-4f3c-b5f8-43d5b64f6714)
-
-> 👩‍💻 You can call `yarn deploy --reset` any time you want a fresh contract, it will get re-deployed even if there are no changes on it.  
-> You may need it when you want to reload the _"Time Left"_ of your tests.
 
 Your `Staker UI` tab should be almost done and working at this point.
 
@@ -178,6 +182,10 @@ Your `Staker UI` tab should be almost done and working at this point.
 > 📝 If you plan on submitting this challenge, be sure to set your `deadline` to at least `block.timestamp + 72 hours`
 
 > 🚀 Run `yarn deploy` to deploy your smart contract to a public network (selected in `hardhat.config.ts`)
+
+![allStakings-blockFrom](https://github.com/scaffold-eth/se-2-challenges/assets/55535804/04725dc8-4a8d-4089-ba82-90f9b94bfbda)
+
+> 💬 Hint: For faster loading of your _"All Stakings"_ page, consider updating the `fromBlock` passed to `useScaffoldEventHistory` in [`packages/nextjs/pages/stakings.tsx`](https://github.com/scaffold-eth/se-2-challenges/blob/challenge-1-decentralized-staking/packages/nextjs/pages/stakings.tsx) to `blocknumber - 10` at which your contract was deployed. Example: `fromBlock: 3750241`.
 
 ---
 

--- a/packages/nextjs/components/stake/StakeContractInteraction.tsx
+++ b/packages/nextjs/components/stake/StakeContractInteraction.tsx
@@ -1,0 +1,96 @@
+import { Address } from "../scaffold-eth";
+import { ETHToPrice } from "./EthToPrice";
+import { utils } from "ethers";
+import humanizeDuration from "humanize-duration";
+import { useAccount } from "wagmi";
+import {
+  useAccountBalance,
+  useDeployedContractInfo,
+  useScaffoldContractRead,
+  useScaffoldContractWrite,
+} from "~~/hooks/scaffold-eth";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
+
+export const StakeContractInteraction = ({ address }: { address?: string }) => {
+  const { address: connectedAddress } = useAccount();
+  const { data: StakerContract } = useDeployedContractInfo("Staker");
+  const { balance: stakerContractBalance } = useAccountBalance(StakerContract?.address);
+  const configuredNetwork = getTargetNetwork();
+
+  // Contract Read Actions
+  const { data: threshold } = useScaffoldContractRead({
+    contractName: "Staker",
+    functionName: "threshold",
+    watch: true,
+  });
+  const { data: timeLeft } = useScaffoldContractRead({
+    contractName: "Staker",
+    functionName: "timeLeft",
+    watch: true,
+  });
+  const { data: myStake } = useScaffoldContractRead({
+    contractName: "Staker",
+    functionName: "balances",
+    args: [connectedAddress],
+    watch: true,
+  });
+
+  // Contract Write Actions
+  const { writeAsync: stakeETH } = useScaffoldContractWrite({
+    contractName: "Staker",
+    functionName: "stake",
+    value: "0.5",
+  });
+  const { writeAsync: execute } = useScaffoldContractWrite({
+    contractName: "Staker",
+    functionName: "execute",
+  });
+  const { writeAsync: withdrawETH } = useScaffoldContractWrite({
+    contractName: "Staker",
+    functionName: "withdraw",
+  });
+
+  return (
+    <div className="flex items-center flex-col flex-grow w-full px-4">
+      <div className="flex flex-col items-center space-y-8 bg-base-100 shadow-lg shadow-secondary border-8 border-secondary rounded-xl p-6 mt-24 w-full max-w-lg">
+        <div className="flex flex-col w-full items-center">
+          <p className="block text-2xl mt-0 mb-2 font-semibold">Staker Contract</p>
+          <Address address={address} size="xl" />
+        </div>
+        <div className="flex items-start justify-around w-full">
+          <div className="flex flex-col items-center justify-center w-1/2">
+            <p className="block text-xl mt-0 mb-1 font-semibold">Time Left</p>
+            <p className="m-0 p-0">{timeLeft ? `${humanizeDuration(timeLeft.toNumber() * 1000)} left` : 0}</p>
+          </div>
+          <div className="flex flex-col items-center w-1/2">
+            <p className="block text-xl mt-0 mb-1 font-semibold">You Staked</p>
+            <span>
+              {myStake ? utils.formatEther(myStake.toString()) : 0} {configuredNetwork.nativeCurrency.symbol}
+            </span>
+          </div>
+        </div>
+        <div className="flex flex-col items-center shrink-0 w-full">
+          <p className="block text-xl mt-0 mb-1 font-semibold">Total Staked</p>
+          <div className="flex space-x-2">
+            {<ETHToPrice value={stakerContractBalance != null ? stakerContractBalance.toString() : undefined} />}
+            <span>/</span>
+            {<ETHToPrice value={threshold && utils.formatEther(threshold)} />}
+          </div>
+        </div>
+        <div className="flex flex-col space-y-5">
+          <div className="flex space-x-7">
+            <button className="btn btn-primary" onClick={() => execute()}>
+              Execute!
+            </button>
+            <button className="btn btn-primary" onClick={() => withdrawETH()}>
+              Withdraw
+            </button>
+          </div>
+          <button className="btn btn-primary" onClick={() => stakeETH()}>
+            🥩 Stake 0.5 ether!
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/nextjs/components/stake/index.tsx
+++ b/packages/nextjs/components/stake/index.tsx
@@ -1,1 +1,2 @@
 export * from "./EthToPrice";
+export * from "./StakeContractInteraction";

--- a/packages/nextjs/pages/stakerUI.tsx
+++ b/packages/nextjs/pages/stakerUI.tsx
@@ -1,107 +1,14 @@
-import { utils } from "ethers";
-import humanizeDuration from "humanize-duration";
 import type { NextPage } from "next";
-import { useAccount, useBlockNumber } from "wagmi";
 import { MetaHeader } from "~~/components/MetaHeader";
-import { Address } from "~~/components/scaffold-eth";
-import { ETHToPrice } from "~~/components/stake";
-import {
-  useAccountBalance,
-  useDeployedContractInfo,
-  useScaffoldContractRead,
-  useScaffoldContractWrite,
-} from "~~/hooks/scaffold-eth";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
+import { StakeContractInteraction } from "~~/components/stake";
+import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
 
 const StakerUI: NextPage = () => {
-  const { address: connectedAddress } = useAccount();
   const { data: StakerContract } = useDeployedContractInfo("Staker");
-  const { balance: stakerContractBalance } = useAccountBalance(StakerContract?.address);
-  const configuredNetwork = getTargetNetwork();
-
-  // Contract Read Actions
-  const { data: threshold, refetch: refetchThreshold } = useScaffoldContractRead({
-    contractName: "Staker",
-    functionName: "threshold",
-    watch: true,
-  });
-  const { data: timeLeft, refetch: refetchTimeLeft } = useScaffoldContractRead({
-    contractName: "Staker",
-    functionName: "timeLeft",
-    watch: true,
-  });
-  const { data: myStake, refetch: refetchMyStake } = useScaffoldContractRead({
-    contractName: "Staker",
-    functionName: "balances",
-    args: [connectedAddress],
-    watch: true,
-  });
-  useBlockNumber({
-    onBlock: async () => {
-      await Promise.all([refetchTimeLeft(), refetchMyStake(), refetchThreshold()]);
-    },
-    watch: true,
-  });
-
-  // Contract Write Actions
-  const { writeAsync: stakeETH } = useScaffoldContractWrite({
-    contractName: "Staker",
-    functionName: "stake",
-    value: "0.5",
-  });
-  const { writeAsync: execute } = useScaffoldContractWrite({
-    contractName: "Staker",
-    functionName: "execute",
-  });
-  const { writeAsync: withdrawETH } = useScaffoldContractWrite({
-    contractName: "Staker",
-    functionName: "withdraw",
-  });
-
   return (
     <>
       <MetaHeader />
-      <div className="flex items-center flex-col flex-grow w-full px-4">
-        <div className="flex flex-col items-center space-y-8 bg-base-100 shadow-lg shadow-secondary border-8 border-secondary rounded-xl p-6 mt-24 w-full max-w-lg">
-          <div className="flex flex-col w-full items-center">
-            <p className="block text-2xl mt-0 mb-2 font-semibold">Staker Contract</p>
-            <Address address={StakerContract?.address} size="xl" />
-          </div>
-          <div className="flex items-start justify-around w-full">
-            <div className="flex flex-col items-center justify-center w-1/2">
-              <p className="block text-xl mt-0 mb-1 font-semibold">Time Left</p>
-              <p className="m-0 p-0">{timeLeft ? `${humanizeDuration(timeLeft.toNumber() * 1000)} left` : 0}</p>
-            </div>
-            <div className="flex flex-col items-center w-1/2">
-              <p className="block text-xl mt-0 mb-1 font-semibold">You Staked</p>
-              <span>
-                {myStake ? utils.formatEther(myStake.toString()) : 0} {configuredNetwork.nativeCurrency.symbol}
-              </span>
-            </div>
-          </div>
-          <div className="flex flex-col items-center shrink-0 w-full">
-            <p className="block text-xl mt-0 mb-1 font-semibold">Total Staked</p>
-            <div className="flex space-x-2">
-              {<ETHToPrice value={stakerContractBalance != null ? stakerContractBalance.toString() : undefined} />}
-              <span>/</span>
-              {<ETHToPrice value={threshold && utils.formatEther(threshold)} />}
-            </div>
-          </div>
-          <div className="flex flex-col space-y-5">
-            <div className="flex space-x-7">
-              <button className="btn btn-primary" onClick={() => execute()}>
-                Execute!
-              </button>
-              <button className="btn btn-primary" onClick={() => withdrawETH()}>
-                Withdraw
-              </button>
-            </div>
-            <button className="btn btn-primary" onClick={() => stakeETH()}>
-              🥩 Stake 0.5 ether!
-            </button>
-          </div>
-        </div>
-      </div>
+      <StakeContractInteraction key={StakerContract?.address} address={StakerContract?.address} />
     </>
   );
 };

--- a/packages/nextjs/pages/stakerUI.tsx
+++ b/packages/nextjs/pages/stakerUI.tsx
@@ -1,7 +1,7 @@
 import { utils } from "ethers";
 import humanizeDuration from "humanize-duration";
 import type { NextPage } from "next";
-import { useAccount } from "wagmi";
+import { useAccount, useBlockNumber } from "wagmi";
 import { MetaHeader } from "~~/components/MetaHeader";
 import { Address } from "~~/components/scaffold-eth";
 import { ETHToPrice } from "~~/components/stake";
@@ -20,19 +20,26 @@ const StakerUI: NextPage = () => {
   const configuredNetwork = getTargetNetwork();
 
   // Contract Read Actions
-  const { data: threshold } = useScaffoldContractRead({
+  const { data: threshold, refetch: refetchThreshold } = useScaffoldContractRead({
     contractName: "Staker",
     functionName: "threshold",
+    watch: true,
   });
-  const { data: timeLeft } = useScaffoldContractRead({
+  const { data: timeLeft, refetch: refetchTimeLeft } = useScaffoldContractRead({
     contractName: "Staker",
     functionName: "timeLeft",
     watch: true,
   });
-  const { data: myStake } = useScaffoldContractRead({
+  const { data: myStake, refetch: refetchMyStake } = useScaffoldContractRead({
     contractName: "Staker",
     functionName: "balances",
     args: [connectedAddress],
+    watch: true,
+  });
+  useBlockNumber({
+    onBlock: async () => {
+      await Promise.all([refetchTimeLeft(), refetchMyStake(), refetchThreshold()]);
+    },
     watch: true,
   });
 

--- a/packages/nextjs/pages/stakings.tsx
+++ b/packages/nextjs/pages/stakings.tsx
@@ -11,6 +11,7 @@ const Stakings: NextPage = () => {
     eventName: "Stake",
     fromBlock: 0,
   });
+  console.log("Stakevents", stakeEvents);
 
   if (isLoading)
     return (
@@ -47,9 +48,9 @@ const Stakings: NextPage = () => {
                   return (
                     <tr key={index}>
                       <td>
-                        <Address address={event.args.staker} />
+                        <Address address={event.args[0]} />
                       </td>
-                      <td>{event.args.amount && utils.formatEther(event.args.amount.toString())} ETH</td>
+                      <td>{event.args[1] && utils.formatEther(event.args[1].toString())} ETH</td>
                     </tr>
                   );
                 })

--- a/packages/nextjs/pages/stakings.tsx
+++ b/packages/nextjs/pages/stakings.tsx
@@ -11,7 +11,6 @@ const Stakings: NextPage = () => {
     eventName: "Stake",
     fromBlock: 0,
   });
-  console.log("Stakevents", stakeEvents);
 
   if (isLoading)
     return (


### PR DESCRIPTION
### Desc : 
It seems that the Staking UI was not updating when we were trying locally doing `yarn deploy --reset`

### Solution : 
used [useBlockNumber](https://0.12.x.wagmi.sh/react/hooks/useBlockNumber) to forcefully refetch all the red variable once new block is added. 

### Other solution explored : 
I tried all the options for `useContractRead` but none work (as we also encountered here -> https://github.com/scaffold-eth/scaffold-eth-2/pull/177#issuecomment-1435948027 (seems a bit hacky but found this to be minimal / working nicely)

PS: For SE-2-chall we are still using v12 wagmi and here are its docs -> https://0.12.x.wagmi.sh/

### Reason for the issue : 
Turns out the issue was related to wagmi cache problem, wagmi was using `cache` instead of refetching all the `read variables` (it does this until you hard refresh the page, or go to different tab and come back)

We already had some issues with wagmi `cache` in wagmi version less than `v1` checkout https://github.com/scaffold-eth/scaffold-eth-2/pull/177#issuecomment-1435948027  (but don't know if that still exists in `v1`) 