### PR TITLE
Challenge 1 Wording Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ uint256 public constant threshold = 1 ether;
 
 - [ ] Do you see the balance of the `Staker` contract go up when you `stake()`?
 - [ ] Is your `balance` correctly tracked?
-- [ ] Do you see the events in the `All Stakings` tab?
+- [ ] Do you see the events in the `Stake Events` tab?
 
   ![allStakings](https://github.com/scaffold-eth/se-2-challenges/assets/55535804/80bcc843-034c-4547-8535-129ed494a204)
 
@@ -185,7 +185,7 @@ Your `Staker UI` tab should be almost done and working at this point.
 
 ![allStakings-blockFrom](https://github.com/scaffold-eth/se-2-challenges/assets/55535804/04725dc8-4a8d-4089-ba82-90f9b94bfbda)
 
-> 💬 Hint: For faster loading of your _"All Stakings"_ page, consider updating the `fromBlock` passed to `useScaffoldEventHistory` in [`packages/nextjs/pages/stakings.tsx`](https://github.com/scaffold-eth/se-2-challenges/blob/challenge-1-decentralized-staking/packages/nextjs/pages/stakings.tsx) to `blocknumber - 10` at which your contract was deployed. Example: `fromBlock: 3750241`.
+> 💬 Hint: For faster loading of your _"Staking Events"_ page, consider updating the `fromBlock` passed to `useScaffoldEventHistory` in [`packages/nextjs/pages/stakings.tsx`](https://github.com/scaffold-eth/se-2-challenges/blob/challenge-1-decentralized-staking/packages/nextjs/pages/stakings.tsx) to `blocknumber - 10` at which your contract was deployed. Example: `fromBlock: 3750241`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Your `Staker UI` tab should be almost done and working at this point.
 
 ![allStakings-blockFrom](https://github.com/scaffold-eth/se-2-challenges/assets/55535804/04725dc8-4a8d-4089-ba82-90f9b94bfbda)
 
-> 💬 Hint: For faster loading of your _"Staking Events"_ page, consider updating the `fromBlock` passed to `useScaffoldEventHistory` in [`packages/nextjs/pages/stakings.tsx`](https://github.com/scaffold-eth/se-2-challenges/blob/challenge-1-decentralized-staking/packages/nextjs/pages/stakings.tsx) to `blocknumber - 10` at which your contract was deployed. Example: `fromBlock: 3750241`.
+> 💬 Hint: For faster loading of your _"Stake Events"_ page, consider updating the `fromBlock` passed to `useScaffoldEventHistory` in [`packages/nextjs/pages/stakings.tsx`](https://github.com/scaffold-eth/se-2-challenges/blob/challenge-1-decentralized-staking/packages/nextjs/pages/stakings.tsx) to `blocknumber - 10` at which your contract was deployed. Example: `fromBlock: 3750241`.
 
 ---
 

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -54,7 +54,7 @@ export const Header = () => {
       <li>
         <NavLink href="/stakings">
           <InboxStackIcon className="h-4 w-4" />
-          All Stakings
+          Stake Events
         </NavLink>
       </li>
       <li>

--- a/packages/nextjs/components/stake/StakeContractInteraction.tsx
+++ b/packages/nextjs/components/stake/StakeContractInteraction.tsx
@@ -60,7 +60,7 @@ export const StakeContractInteraction = ({ address }: { address?: string }) => {
         <div className="flex items-start justify-around w-full">
           <div className="flex flex-col items-center justify-center w-1/2">
             <p className="block text-xl mt-0 mb-1 font-semibold">Time Left</p>
-            <p className="m-0 p-0">{timeLeft ? `${humanizeDuration(timeLeft.toNumber() * 1000)} left` : 0}</p>
+            <p className="m-0 p-0">{timeLeft ? `${humanizeDuration(timeLeft.toNumber() * 1000)}` : 0}</p>
           </div>
           <div className="flex flex-col items-center w-1/2">
             <p className="block text-xl mt-0 mb-1 font-semibold">You Staked</p>


### PR DESCRIPTION
Fixes #28 

Changes the name of the events tab to Stake Events.

Updates readme to match that change.

Removes the 'left' from the second line in the Time Left section as it's redundant.