### PR TITLE
fix inputs breaks UI & update EtherInput to take in .number values

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
@@ -1,9 +1,11 @@
 import { useMemo, useState } from "react";
 import { ArrowsRightLeftIcon } from "@heroicons/react/24/outline";
-import { CommonInputProps, InputBase, SIGNED_NUMBER_REGEX } from "~~/components/scaffold-eth";
+import { CommonInputProps, InputBase } from "~~/components/scaffold-eth";
 import { useGlobalState } from "~~/services/store/store";
 
 const MAX_DECIMALS_USD = 2;
+// REGEX for number inputs (only allow numbers and a single decimal point)
+export const NUMBER_REGEX = /^\.?\d+\.?\d*$/;
 
 function etherValueToDisplayValue(usdMode: boolean, etherValue: string, nativeCurrencyPrice: number) {
   if (usdMode && nativeCurrencyPrice) {
@@ -47,6 +49,7 @@ export const EtherInput = ({ value, name, placeholder, onChange }: CommonInputPr
   const [transitoryDisplayValue, setTransitoryDisplayValue] = useState<string>();
   const nativeCurrencyPrice = useGlobalState(state => state.nativeCurrencyPrice);
   const [usdMode, setUSDMode] = useState(false);
+  const [inputError, setInputError] = useState(false);
 
   // The displayValue is derived from the ether value that is controlled outside of the component
   // In usdMode, it is converted to its usd value, in regular mode it is unaltered
@@ -61,8 +64,10 @@ export const EtherInput = ({ value, name, placeholder, onChange }: CommonInputPr
   }, [nativeCurrencyPrice, transitoryDisplayValue, usdMode, value]);
 
   const handleChangeNumber = (newValue: string) => {
-    if (newValue && !SIGNED_NUMBER_REGEX.test(newValue)) {
-      return;
+    if (newValue && !NUMBER_REGEX.test(newValue)) {
+      setInputError(true);
+    } else {
+      setInputError(false);
     }
 
     // Following condition is a fix to prevent usdMode from experiencing different display values
@@ -94,6 +99,7 @@ export const EtherInput = ({ value, name, placeholder, onChange }: CommonInputPr
     <InputBase
       name={name}
       value={displayValue}
+      error={inputError}
       placeholder={placeholder}
       onChange={handleChangeNumber}
       prefix={<span className="pl-4 -mr-2 text-accent self-center">{usdMode ? "$" : "Ξ"}</span>}
@@ -101,7 +107,7 @@ export const EtherInput = ({ value, name, placeholder, onChange }: CommonInputPr
         <button
           className={`btn btn-primary h-[2.2rem] min-h-[2.2rem] ${nativeCurrencyPrice > 0 ? "" : "hidden"}`}
           onClick={toggleMode}
-          disabled={!usdMode && !nativeCurrencyPrice}
+          disabled={inputError || (!usdMode && !nativeCurrencyPrice)}
         >
           <ArrowsRightLeftIcon className="h-3 w-3 cursor-pointer" aria-hidden="true" />
         </button>

--- a/packages/nextjs/components/scaffold-eth/Input/IntegerInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/IntegerInput.tsx
@@ -60,3 +60,4 @@ export const IntegerInput = ({
     />
   );
 };
+


### PR DESCRIPTION
### Demo : 

https://github.com/scaffold-eth/se-2-challenges/assets/80153681/17b0fbb2-dd2e-41e6-837e-77a9f49e8ad1

Fixes #44 

<details>
<summary>My Contract solution if anyone wants refer : </summary>
      
            pragma solidity >=0.8.0 <0.9.0;
            // SPDX-License-Identifier: MIT
    
    import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
    import "@openzeppelin/contracts/utils/math/SafeMath.sol";
    
    /**
     * @title DEX
     * @author stevepham.eth and m00npapi.eth
     * @notice this is a single token pair reserves DEX, ref: "Scaffold-ETH Challenge 4" as per https://speedrunethereum.com/, README.md and full branch (front-end) made with lots of inspiration from pre-existing example repos in scaffold-eth organization.
     */
    contract DEX {
        /* ========== GLOBAL VARIABLES ========== */
    
        uint256 public totalLiquidity; //total amount of liquidity provider tokens (LPTs) minted (NOTE: that LPT "price" is tied to the ratio, and thus price of the assets within this AMM)
        mapping(address => uint256) public liquidity; //liquidity of each depositor
        using SafeMath for uint256; //outlines use of SafeMath for uint256 variables
        IERC20 token; //instantiates the imported contract
    
        /* ========== EVENTS ========== */
    
        /**
         * @notice Emitted when ethToToken() swap transacted
         */
        event EthToTokenSwap(
            address swapper,
            string txDetails,
            uint256 ethInput,
            uint256 tokenOutput
        );
    
        /**
         * @notice Emitted when tokenToEth() swap transacted
         */
        event TokenToEthSwap(
            address swapper,
            string txDetails,
            uint256 tokensInput,
            uint256 ethOutput
        );
    
        /**
         * @notice Emitted when liquidity provided to DEX and mints LPTs.
         */
        event LiquidityProvided(
            address liquidityProvider,
            uint256 tokensInput,
            uint256 ethInput,
            uint256 liquidityMinted
        );
    
        /**
         * @notice Emitted when liquidity removed from DEX and decreases LPT count within DEX.
         */
        event LiquidityRemoved(
            address liquidityRemover,
            uint256 tokensOutput,
            uint256 ethOutput,
            uint256 liquidityWithdrawn
        );
    
        /* ========== CONSTRUCTOR ========== */
    
        constructor(address token_addr) public {
            token = IERC20(token_addr); //specifies the token address that will hook into the interface and be used through the variable 'token'
        }
    
        /* ========== MUTATIVE FUNCTIONS ========== */
    
        /**
         * @notice initializes amount of tokens that will be transferred to the DEX itself from the erc20 contract mintee (and only them based on how Balloons.sol is written). Loads contract up with both ETH and Balloons.
         * @param tokens amount to be transferred to DEX
         * @return totalLiquidity is the number of LPTs minting as a result of deposits made to DEX contract
         * NOTE: since ratio is 1:1, this is fine to initialize the totalLiquidity (wrt to balloons) as equal to eth balance of contract.
         */
        function init(uint256 tokens) public payable returns (uint256) {
            require(totalLiquidity == 0, "DEX: init - already has liquidity");
            totalLiquidity = address(this).balance;
            liquidity[msg.sender] = totalLiquidity;
            require(
                token.transferFrom(msg.sender, address(this), tokens),
                "DEX: init - transfer did not transact"
            );
            return totalLiquidity;
        }
    
        /**
         * @notice returns yOutput, or yDelta for xInput (or xDelta)
         */
        function price(
            uint256 xInput,
            uint256 xReserves,
            uint256 yReserves
        ) public view returns (uint256 yOutput) {
            uint256 xInputWithFee = xInput.mul(997);
            uint256 numerator = xInputWithFee.mul(yReserves);
            uint256 denominator = (xReserves.mul(1000)).add(xInputWithFee);
            return (numerator / denominator);
        }
    
        /**
         * @notice returns liquidity for a user. Note this is notneeded typically due to the `liquidity()` mapping variable being public and having a getter as a result. This is left though as it is used within the front end code (App.jsx).
         */
        function getLiquidity(address lp) public view returns (uint256) {
            return liquidity[lp];
        }
    
        /**
         * @notice sends Ether to DEX in exchange for $BAL
         */
        function ethToToken() public payable returns (uint256 tokenOutput) {
            require(msg.value > 0, "cannot swap 0 ETH");
            uint256 ethReserve = address(this).balance.sub(msg.value);
            uint256 token_reserve = token.balanceOf(address(this));
            uint256 tokenOutput = price(msg.value, ethReserve, token_reserve);
    
            require(
                token.transfer(msg.sender, tokenOutput),
                "ethToToken(): reverted swap."
            );
            emit EthToTokenSwap(
                msg.sender,
                "Eth to Balloons",
                msg.value,
                tokenOutput
            );
            return tokenOutput;
        }
    
        /**
         * @notice sends $BAL tokens to DEX in exchange for Ether
         */
        function tokenToEth(uint256 tokenInput) public returns (uint256 ethOutput) {
            require(tokenInput > 0, "cannot swap 0 tokens");
            uint256 token_reserve = token.balanceOf(address(this));
            uint256 ethOutput = price(
                tokenInput,
                token_reserve,
                address(this).balance
            );
            require(
                token.transferFrom(msg.sender, address(this), tokenInput),
                "tokenToEth(): reverted swap."
            );
            (bool sent, ) = msg.sender.call{value: ethOutput}("");
            require(sent, "tokenToEth: revert in transferring eth to you!");
            emit TokenToEthSwap(
                msg.sender,
                "Balloons to ETH",
                ethOutput,
                tokenInput
            );
            return ethOutput;
        }
    
        /**
         * @notice allows deposits of $BAL and $ETH to liquidity pool
         * NOTE: parameter is the msg.value sent with this function call. That amount is used to determine the amount of $BAL needed as well and taken from the depositor.
         * NOTE: user has to make sure to give DEX approval to spend their tokens on their behalf by calling approve function prior to this function call.
         * NOTE: Equal parts of both assets will be removed from the user's wallet with respect to the price outlined by the AMM.
         */
        function deposit() public payable returns (uint256 tokensDeposited) {
            require(msg.value > 0, "Must send value when depositing");
            uint256 ethReserve = address(this).balance.sub(msg.value);
            uint256 tokenReserve = token.balanceOf(address(this));
            uint256 tokenDeposit;
    
            tokenDeposit = (msg.value.mul(tokenReserve) / ethReserve).add(1);
            uint256 liquidityMinted = msg.value.mul(totalLiquidity) / ethReserve;
            liquidity[msg.sender] = liquidity[msg.sender].add(liquidityMinted);
            totalLiquidity = totalLiquidity.add(liquidityMinted);
    
            require(token.transferFrom(msg.sender, address(this), tokenDeposit));
            emit LiquidityProvided(
                msg.sender,
                liquidityMinted,
                msg.value,
                tokenDeposit
            );
            return tokenDeposit;
        }
    
        /**
         * @notice allows withdrawal of $BAL and $ETH from liquidity pool
         * NOTE: with this current code, the msg caller could end up getting very little back if the liquidity is super low in the pool. I guess they could see that with the UI.
         */
        function withdraw(
            uint256 amount
        ) public returns (uint256 eth_amount, uint256 token_amount) {
            require(
                liquidity[msg.sender] >= amount,
                "withdraw: sender does not have enough liquidity to withdraw."
            );
            uint256 ethReserve = address(this).balance;
            uint256 tokenReserve = token.balanceOf(address(this));
            uint256 ethWithdrawn;
    
            ethWithdrawn = amount.mul(ethReserve) / totalLiquidity;
    
            uint256 tokenAmount = amount.mul(tokenReserve) / totalLiquidity;
            liquidity[msg.sender] = liquidity[msg.sender].sub(amount);
            totalLiquidity = totalLiquidity.sub(amount);
            (bool sent, ) = payable(msg.sender).call{value: ethWithdrawn}("");
            require(sent, "withdraw(): revert in transferring eth to you!");
            require(token.transfer(msg.sender, tokenAmount));
            emit LiquidityRemoved(msg.sender, amount, ethWithdrawn, tokenAmount);
            return (ethWithdrawn, tokenAmount);
        }
    }
   

   
</details>
 

