### PR TITLE
remove vercel:yolo from root pacakge.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "next:check-types": "yarn workspace @se-2/nextjs check-types",
     "postinstall": "husky install",
     "precommit": "lint-staged",
-    "vercel": "yarn workspace @se-2/nextjs vercel",
-    "vercel:yolo": "yarn workspace @se-2/nextjs vercel:yolo"
+    "vercel": "yarn workspace @se-2/nextjs vercel"
   },
   "packageManager": "yarn@3.2.3",
   "devDependencies": {


### PR DESCRIPTION
Removing vercel:yolo from root pacakge.json, we forgot to remove 

`yarn vercel` by default runs `yarn vecel:yolo` since we have ignore all checks in `next.config.ts`