### PR TITLE
Challenge 4: autograder test fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Let’s edit the `DEX.sol` smart contract and add two new functions for swapping
         uint256 tokenOutput = price(msg.value, ethReserve, token_reserve);
 
         require(token.transfer(msg.sender, tokenOutput), "ethToToken(): reverted swap.");
-        emit EthToTokenSwap(msg.sender, msg.value, tokenOutput);
+        emit EthToTokenSwap(msg.sender, tokenOutput, msg.value);
         return tokenOutput;
     }
 

--- a/packages/hardhat/contracts/DEX.sol
+++ b/packages/hardhat/contracts/DEX.sol
@@ -21,7 +21,7 @@ contract DEX {
     /**
      * @notice Emitted when ethToToken() swap transacted
      */
-    event EthToTokenSwap(address swapper, uint256 ethInput, uint256 tokenOutput);
+    event EthToTokenSwap(address swapper, uint256 tokenOutput, uint256 ethInput);
 
     /**
      * @notice Emitted when tokenToEth() swap transacted


### PR DESCRIPTION
This was reported on TG Dex chat : 

It seems that the autograder test checks expects (3rd argument) i.e index 2 as ethInput : 
https://github.com/scaffold-eth/scaffold-eth-challenges/blob/8b7c88f0a77d3487bb3a3b6ced792c8c1cee7cf4/packages/hardhat/test/constantProductTest.js#L131C1-L131C57

The reason for so is in SE-1-challenge we are logging `EthToTokenSwap` as : 

```solidity
emit EthToTokenSwap(msg.sender, "Eth to Balloons", msg.value, tokenOutput);
```

checkout [here](https://github.com/scaffold-eth/scaffold-eth-challenges/tree/challenge-4-dex#%EF%B8%8F-checkpoint-4-trading-), notice there is "Eth to Balloons" string in between which makes `msg.value`(ethInput) as 3rd argument 


--- 


Currently in SE-2 challenge Dex we don't have string parameter in between our event `EthToTokenSwap` only has 3 arguments and SE-1 challenge had 4 

Solution : 

1. Swap the 2nd and 3rd argument in challenge template (which I did here)
2. Make the event signature similar to SE-1-challenge


What do you guys think should we make event signature similar to SE-1 ? that in between "Eth to ballons" string ? 