### PR TITLE
fix test to match autograder test

### DIFF
--- a/packages/hardhat/test/Challenge4.ts
+++ b/packages/hardhat/test/Challenge4.ts
@@ -7,13 +7,14 @@
 // you can even run mint commands if the tests pass like:
 // yarn test && echo "PASSED" || echo "FAILED"
 //
-import { ethers, network, deployments } from 'hardhat';
-import { expect } from 'chai';
-import { Contract } from 'ethers';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signers';
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { Contract } from "ethers";
+import { TransactionReceipt } from "@ethersproject/providers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
 
 describe("🚩 Challenge 4: ⚖️ 🪙 DEX", () => {
-
   // this.timeout(45000);
 
   let dexContract: Contract;
@@ -22,126 +23,376 @@ describe("🚩 Challenge 4: ⚖️ 🪙 DEX", () => {
   let user2: SignerWithAddress;
   let user3: SignerWithAddress;
 
-  before(async () => {
-    [deployer, user2, user3] = await ethers.getSigners();
+  let contractArtifact: string;
+  if (process.env.CONTRACT_ADDRESS) {
+    contractArtifact = `contracts/${process.env.CONTRACT_ADDRESS}.sol:DEX`;
+  } else {
+    contractArtifact = "contracts/DEX.sol:DEX";
+  }
 
-    const Balloons = await ethers.getContractFactory("Balloons");
-    balloonsContract = await Balloons.deploy();
+  function getEventValue(txReceipt: TransactionReceipt, eventNumber: number) {
+    const log = txReceipt.logs.find(log => log.address === dexContract.address);
+    const logDescr = log && dexContract.interface.parseLog(log);
+    const args = logDescr?.args;
+    return args && args[eventNumber]; // index of ethAmount in event
+  }
 
-    const DEX = await ethers.getContractFactory("DEX");
-    dexContract = await DEX.deploy(balloonsContract.address);
+  async function deployNewInstance() {
+    before("Deploying fresh contracts", async function () {
+      console.log("\t", " 🛫 Deploying new contracts...");
 
-    await balloonsContract.approve(dexContract.address, ethers.utils.parseEther("100"));
+      const BalloonsContract = await ethers.getContractFactory("Balloons");
+      balloonsContract = await BalloonsContract.deploy();
 
-    await dexContract.init(ethers.utils.parseEther("5"), {
-      value: ethers.utils.parseEther("5"),
-      gasLimit: 200000,
+      const DexContract = await ethers.getContractFactory(contractArtifact);
+      dexContract = await DexContract.deploy(balloonsContract.address);
+
+      await balloonsContract.approve(dexContract.address, ethers.utils.parseEther("100"));
+
+      await dexContract.init(ethers.utils.parseEther("5"), {
+        value: ethers.utils.parseEther("5"),
+        gasLimit: 200000,
+      });
+
+      [deployer, user2, user3] = await ethers.getSigners();
+
+      await balloonsContract.transfer(user2.address, ethers.utils.parseEther("10"));
+      await balloonsContract.transfer(user3.address, ethers.utils.parseEther("10"));
     });
-  });
+  }
 
   // quick fix to let gas reporter fetch data from gas station & coinmarketcap
-  before((done) => {
+  before(done => {
     setTimeout(done, 2000);
   });
 
-  describe("DEX: Standard Path", () => {
-    // TODO: need to add tests that the other functions do not work if we try calling them without init() started.
-    /* TODO checking `price` calcs. Preferably calculation test should be provided by somebody who didn't implement this functions in 
-    challenge to not reproduce mistakes systematically.*/
-    describe("init()", () => {
+  // --------------------- START OF CHECKPOINT 2 ---------------------
+  describe("Checkpoint 2: Reserves", function () {
+    describe("Deploying the contracts and testing the init function", () => {
+      it("Should deploy contracts", async function () {
+        const BalloonsContract = await ethers.getContractFactory("Balloons");
+        balloonsContract = await BalloonsContract.deploy();
 
-      it("Should DEX balance: 5 Ether and 5 BAL ", async () => {
-        expect(
-          await ethers.provider.getBalance(dexContract.address)
-        ).to.equal(ethers.utils.parseEther("5"));
+        const DexContract = await ethers.getContractFactory(contractArtifact);
+        dexContract = await DexContract.deploy(balloonsContract.address);
 
-        expect(await balloonsContract.balanceOf(dexContract.address))
-        .to.equal(ethers.utils.parseEther("5"));
-      });
+        await balloonsContract.approve(dexContract.address, ethers.utils.parseEther("100"));
 
-      describe("ethToToken()", () => {
-        it("Should send 1 Ether to DEX in exchange for _ $BAL", async () => {
-          let tx1 = await dexContract.ethToToken({
-            value: ethers.utils.parseEther("1"),
-          });
-          // TODO: SYNTAX - Figure out how to read eth balance of dex contract and to compare it against the eth sent in via this tx. Also 
-          //figure out why/how to read the event that should be emitted with this too.
-          /* Also, notice, that reference `DEX.sol` could emit *after* `return`, so that they're never emited. It's on your own to find and
-          correct */
-
-          expect(
-            await ethers.provider.getBalance(dexContract.address)
-          ).to.equal(ethers.utils.parseEther("6"));
-
-          // await expect(tx1)
-          //   .emit(dexContract, "EthToTokenSwap")
-          //   .withArgs(user2.address, __, ethers.utils.parseEther("1"));
+        const lpBefore = await dexContract.totalLiquidity();
+        console.log(
+          "\t",
+          " 💦 Expecting total liquidity to be 0 before initializing.  Total liquidity:",
+          ethers.utils.formatEther(lpBefore),
+        );
+        expect(lpBefore).to.equal(0);
+        console.log("\t", " 🔰 Calling init with 5 Eth");
+        await dexContract.init(ethers.utils.parseEther("5"), {
+          value: ethers.utils.parseEther("5"),
+          gasLimit: 200000,
         });
-
-        it("Should send less tokens after the first trade (ethToToken called)", async () => {
-          await dexContract.ethToToken({
-            value: ethers.utils.parseEther("1"),
-          });
-          let tx1 = dexContract.connect(user2).ethToToken({
-            value: ethers.utils.parseEther("1"),
-          });
-          // expect(tx1).emit(dexContract, "EthToTokenSwap").withArgs(user2.address, __, ethers.utils.parseEther("1"));
-        });
-        // could insert more tests to show the declining price, and what happens when the pool becomes very imbalanced.
-      });
-      describe("tokenToEth", async () => {
-        it("Should send 1 $BAL to DEX in exchange for _ $ETH", async () => {
-          const balloons_bal_start = await balloonsContract.balanceOf(dexContract.address);
-
-          let tx1 = await dexContract
-            .tokenToEth(ethers.utils.parseEther("1"));
-
-          //TODO: SYNTAX -  write an expect that takes into account the emitted event from tokenToETH.
-          expect(await balloonsContract.balanceOf(dexContract.address))
-            .to.equal(balloons_bal_start.add(ethers.utils.parseEther("1")));
-        });
-
-        it("Should send less eth after the first trade (tokenToEth() called)", async () => {
-          let tx1 = await dexContract.tokenToEth(ethers.utils.parseEther("1"));
-          const tx1_receipt = await tx1.wait();
-
-          let tx2 = await dexContract.tokenToEth(ethers.utils.parseEther("1"));
-          const tx2_receipt = await tx2.wait();
-
-          function getEthAmount(txReceipt: any) {
-            const logDescr = dexContract.interface.parseLog(
-              txReceipt.logs.find((log: any) => log.address == dexContract.address)
-            );
-            const args = logDescr.args;
-            return args[2]; // index of ethAmount in event
-          }
-          const ethSent_1 = getEthAmount(tx1_receipt);
-          const ethSent_2 = getEthAmount(tx2_receipt);
-          expect(ethSent_2).below(ethSent_1);
-        });
-      });
-
-      describe("deposit", async () => {
-        it("Should deposit 1 ETH and 1 $BAL when pool at 1:1 ratio", async () => {
-          let tx1 = await dexContract.deposit(
-            (ethers.utils.parseEther("5"),
-            {
-              value: ethers.utils.parseEther("5"),
-            })
-          );
-          // TODO: SYNTAX - Write expect() assessing changed liquidty within the pool. Should have an emitted event!
-        });
-      });
-
-      // pool should have 5:5 ETH:$BAL ratio
-      describe("withdraw", async () => {
-        it("Should withdraw 1 ETH and 1 $BAL when pool at 1:1 ratio", async () => {
-          let tx1 = await dexContract
-            .withdraw(ethers.utils.parseEther("1"));
-
-          // TODO: SYNTAX - Write expect() assessing changed liquidty within the pool. Should have an emitted event!
-        });
+        const lpAfter = await dexContract.totalLiquidity();
+        console.log(
+          "\t",
+          " 💦 Expecting new total liquidity to be 5.  Total liquidity:",
+          ethers.utils.formatEther(lpAfter),
+        );
       });
     });
   });
+  // ----------------- END OF CHECKPOINT 2 -----------------
+  // ----------------- START OF CHECKPOINT 3 -----------------
+  describe("Checkpoint 3: Price", async () => {
+    describe("price()", async () => {
+      // https://etherscan.io/address/0x7a250d5630b4cf539739df2c5dacb4c659f2488d#readContract
+      // in Uniswap the fee is build in getAmountOut() function
+      it("Should calculate the price correctly", async function () {
+        let xInput = ethers.utils.parseEther("1");
+        let xReserves = ethers.utils.parseEther("5");
+        let yReserves = ethers.utils.parseEther("5");
+        let yOutput = await dexContract.price(xInput, xReserves, yReserves);
+        expect(
+          yOutput.toString(),
+          "Check your price function's calculations.  Don't forget the 3% fee for liquidity providers, and the function should be view or pure.",
+        ).to.equal("831248957812239453");
+        xInput = ethers.utils.parseEther("1");
+        xReserves = ethers.utils.parseEther("10");
+        yReserves = ethers.utils.parseEther("15");
+        yOutput = await dexContract.price(xInput, xReserves, yReserves);
+        expect(yOutput.toString()).to.equal("1359916340820223697");
+      });
+    });
+  });
+  // ----------------- END OF CHECKPOINT 3 -----------------
+  // ----------------- START OF CHECKPOINT 4 -----------------
+  describe("Checkpoint 4: Trading", function () {
+    deployNewInstance();
+    describe("ethToToken()", function () {
+      it("Should be able to send 1 Ether to DEX in exchange for _ $BAL", async function () {
+        const dex_eth_start = await ethers.provider.getBalance(dexContract.address);
+        console.log("\t", " 💵 Dex contract's initial Eth balance:", ethers.utils.formatEther(dex_eth_start));
+        console.log("\t", " 📞 Calling ethToToken with a value of 1 Eth...");
+        const tx1 = await dexContract.ethToToken({ value: ethers.utils.parseEther("1") });
+
+        expect(tx1, "ethToToken should revert before initalization").not.to.be.reverted;
+
+        console.log("\t", " 🔰 Initializing...");
+        const tx1_receipt = await tx1.wait();
+        const ethSent_1 = getEventValue(tx1_receipt, 2);
+
+        console.log("\t", " 🔼 Expecting the Eth value emitted to be 1.  Value:", ethers.utils.formatEther(ethSent_1));
+        expect(ethSent_1, "Check you are emitting the correct Eth value and in the correct order").to.equal(
+          ethers.utils.parseEther("1"),
+        );
+
+        const dex_eth_after = await ethers.provider.getBalance(dexContract.address);
+        console.log("\t", " 💵 Dex contract's new Eth balance:", ethers.utils.formatEther(dex_eth_after));
+
+        console.log("\t", " 💵 Expecting final Dex balance to have increased by 1...");
+        expect(await ethers.provider.getBalance(dexContract.address)).to.equal(ethers.utils.parseEther("6"));
+      });
+
+      it("Should revert if 0 ETH sent", async function () {
+        await expect(
+          dexContract.ethToToken({ value: ethers.utils.parseEther("0") }),
+          "ethToToken should revert when sending 0 value...",
+        ).to.be.reverted;
+      });
+
+      it("Should send less tokens after the first trade (ethToToken called)", async function () {
+        const user2BalBefore = await balloonsContract.balanceOf(user2.address);
+        console.log("\t", " 💵 User2 initial $BAL balance:", ethers.utils.formatEther(user2BalBefore));
+        console.log("\t", " 🥈 User2 calling ethToToken with value of 1 ETH...");
+        await dexContract.connect(user2).ethToToken({ value: ethers.utils.parseEther("1") });
+
+        const user2BalAfter = await balloonsContract.balanceOf(user2.address);
+        console.log("\t", " 💵 User2 new $BAL balance:", ethers.utils.formatEther(user2BalAfter));
+
+        const user3BalBefore = await balloonsContract.balanceOf(user3.address);
+        console.log("\t", " 💵 User3 initial $BAL balance:", ethers.utils.formatEther(user3BalBefore));
+        console.log("\t", " 🥉 User3 calling ethToToken with value of 1 ETH...");
+        await dexContract.connect(user3).ethToToken({ value: ethers.utils.parseEther("1") });
+
+        const user3BalAfter = await balloonsContract.balanceOf(user3.address);
+        console.log("\t", " 💵 User3 new $BAL balance:", ethers.utils.formatEther(user3BalAfter));
+
+        console.log("\t", " 💵 Expecting User2 to have aquired more $BAL than User3...");
+        expect(user2BalAfter).to.greaterThan(user3BalAfter);
+      });
+
+      it("Should emit an event when ethToToken() called", async function () {
+        await expect(
+          dexContract.ethToToken({ value: ethers.utils.parseEther("1") }),
+          "Make sure you're emitting the EthToTokenSwap event correctly",
+        ).to.emit(dexContract, "EthToTokenSwap");
+      });
+
+      it("Should transfer tokens to purchaser after trade", async function () {
+        const user3_token_before = await balloonsContract.balanceOf(user3.address);
+        console.log("\t", " 💵 User3 initial $BAL balance:", ethers.utils.formatEther(user3_token_before));
+
+        console.log("\t", " 🥉 User3 calling ethToToken with value of 1 ETH...");
+        const tx1 = await dexContract.connect(user3).ethToToken({
+          value: ethers.utils.parseEther("1"),
+        });
+        await tx1.wait();
+
+        const user3_token_after = await balloonsContract.balanceOf(user3.address);
+        console.log("\t", " 💵 User3 new $BAL balance:", ethers.utils.formatEther(user3_token_after));
+
+        const tokenDifferece = user3_token_after.sub(user3_token_before);
+        console.log("\t", " 🥉 Expecting user3's $BAL balance to increase by the correct amount...");
+        expect(tokenDifferece).to.be.equal("277481486896167099");
+      });
+      // could insert more tests to show the declining price, and what happens when the pool becomes very imbalanced.
+    });
+
+    describe("tokenToEth()", async () => {
+      it("Should send 1 $BAL to DEX in exchange for _ $ETH", async function () {
+        const balloons_bal_start = await balloonsContract.balanceOf(dexContract.address);
+        console.log("\t", " 💵 Initial Ballons $BAL balance:", ethers.utils.formatEther(balloons_bal_start));
+        const dex_eth_start = await ethers.provider.getBalance(dexContract.address);
+        console.log("\t", " 💵 Initial DEX Eth balance:", ethers.utils.formatEther(dex_eth_start));
+
+        console.log("\t", " 📞 Calling tokenToEth with 1 Eth...");
+        const tx1 = await dexContract.tokenToEth(ethers.utils.parseEther("1"));
+
+        const balloons_bal_end = await balloonsContract.balanceOf(dexContract.address);
+        console.log("\t", " 💵 Final Ballons $BAL balance:", ethers.utils.formatEther(balloons_bal_end));
+        const dex_eth_end = await ethers.provider.getBalance(dexContract.address);
+        console.log("\t", " 💵 Final DEX Eth balance:", ethers.utils.formatEther(dex_eth_end));
+
+        await expect(tx1).not.to.be.revertedWith("Contract not initialized");
+        // Checks that the balance of the DEX contract has decreased by 1 $BAL
+        console.log("\t", " 🎈 Expecting the $BAL balance of the Ballon contract to have increased by 1...");
+        expect(await balloonsContract.balanceOf(dexContract.address)).to.equal(
+          balloons_bal_start.add(ethers.utils.parseEther("1")),
+        );
+        // Checks that the balance of the DEX contract has increased
+        console.log("\t", " ⚖️ Expecting the balance of the Dex contract to have decreased...");
+        expect(await ethers.provider.getBalance(dexContract.address)).to.lessThan(dex_eth_start);
+      });
+
+      it("Should revert if 0 tokens sent to the DEX", async function () {
+        await expect(dexContract.tokenToEth(ethers.utils.parseEther("0"))).to.be.reverted;
+      });
+
+      it("Should emit event TokenToEthSwap when tokenToEth() called", async function () {
+        await expect(
+          dexContract.tokenToEth(ethers.utils.parseEther("1")),
+          "Make sure you're emitting the TokenToEthSwap event correctly",
+        ).to.emit(dexContract, "TokenToEthSwap");
+      });
+
+      it("Should send less eth after the first trade (tokenToEth() called)", async function () {
+        const dex_eth_start = await ethers.provider.getBalance(dexContract.address);
+        console.log("\t", " 💵 Initial Dex balance:", ethers.utils.formatEther(dex_eth_start));
+        console.log("\t", " 📞 Calling tokenToEth with 1 Eth...");
+        const tx1 = await dexContract.tokenToEth(ethers.utils.parseEther("1"));
+        await tx1.wait();
+
+        const dex_eth_next = await ethers.provider.getBalance(dexContract.address);
+        const tx1difference = dex_eth_next.sub(dex_eth_start);
+        console.log(
+          "\t",
+          " 💵 Next Dex balance:",
+          ethers.utils.formatEther(dex_eth_next),
+          " Eth sent:",
+          ethers.utils.formatEther(tx1difference.mul(-1)),
+        );
+
+        console.log("\t", " 📞 Calling tokenToEth with 1 Eth...");
+        const tx2 = await dexContract.tokenToEth(ethers.utils.parseEther("1"));
+        await tx2.wait();
+
+        const dex_eth_end = await ethers.provider.getBalance(dexContract.address);
+        const tx2difference = dex_eth_end.sub(dex_eth_next);
+        console.log(
+          "\t",
+          " 💵 Final Dex balance:",
+          ethers.utils.formatEther(dex_eth_end),
+          " Eth sent:",
+          ethers.utils.formatEther(tx2difference.mul(-1)),
+        );
+
+        console.log("\t", " ➖ Expecting the first call to get more Eth than the second...");
+        expect(tx2difference).to.greaterThan(tx1difference);
+      });
+    });
+  });
+  // ----------------- END OF CHECKPOINT 4 -----------------
+  // ----------------- START OF CHECKPOINT 5 -----------------
+  describe("Checkpoint 5: Liquidity", async () => {
+    describe("deposit()", async () => {
+      deployNewInstance();
+      it("Should increase liquidity in the pool when ETH is deposited", async function () {
+        console.log("\t", " 💵 Approving 100 ETH...");
+        await balloonsContract.connect(user2).approve(dexContract.address, ethers.utils.parseEther("100"));
+        const liquidity_start = await dexContract.totalLiquidity();
+        console.log("\t", " ⚖️ Starting Dex liquidity", ethers.utils.formatEther(liquidity_start));
+        const user2liquidity = await dexContract.getLiquidity(user2.address);
+        console.log(
+          "\t",
+          " ⚖️ Expecting user's liquidity to be 0. Liquidity:",
+          ethers.utils.formatEther(user2liquidity),
+        );
+        expect(user2liquidity).to.equal("0");
+        console.log("\t", " 🔼 Expecting the deposit function to emit correctly...");
+        await expect(
+          dexContract.connect(user2).deposit((ethers.utils.parseEther("5"), { value: ethers.utils.parseEther("5") })),
+          "Check the order of the values when emitting LiquidityProvided: msg.sender, liquidityMinted, msg.value, tokenDeposit",
+        )
+          .to.emit(dexContract, "LiquidityProvided")
+          .withArgs(anyValue, ethers.utils.parseEther("5"), ethers.utils.parseEther("5"), anyValue);
+        const liquidity_end = await dexContract.totalLiquidity();
+        console.log(
+          "\t",
+          " 💸 Final liquidity should increase by 5.  Final liquidity:",
+          ethers.utils.formatEther(liquidity_end),
+        );
+        expect(liquidity_end, "Total liquidity should increase").to.equal(
+          liquidity_start.add(ethers.utils.parseEther("5")),
+        );
+        const user_lp = await dexContract.getLiquidity(user2.address);
+        console.log("\t", " ⚖️ User's liquidity provided should be 5. LP:", ethers.utils.formatEther(user_lp));
+        expect(user_lp.toString(), "User's liquidity provided should be 5.").to.equal(ethers.utils.parseEther("5"));
+      });
+
+      it("Should revert if 0 ETH deposited", async function () {
+        await expect(
+          dexContract.deposit((ethers.utils.parseEther("0"), { value: ethers.utils.parseEther("0") })),
+          "Should revert if 0 value is sent",
+        ).to.be.reverted;
+      });
+    });
+    // pool should have 5:5 ETH:$BAL ratio
+    describe("withdraw()", async () => {
+      deployNewInstance();
+      it("Should withdraw 1 ETH and 1 $BAL when pool is at a 1:1 ratio", async function () {
+        const startingLiquidity = await dexContract.totalLiquidity();
+        console.log("\t", " ⚖️ Starting liquidity:", ethers.utils.formatEther(startingLiquidity));
+        const userBallonsBalance = await balloonsContract.balanceOf(deployer.address);
+        console.log("\t", " 💵 User's starting $BAL balance:", ethers.utils.formatEther(userBallonsBalance));
+
+        console.log("\t", " 🔽 Calling withdraw with with a value of 1 Eth...");
+        const tx1 = await dexContract.withdraw(ethers.utils.parseEther("1"));
+        const userBallonsBalanceAfter = await balloonsContract.balanceOf(deployer.address);
+        const tx1_receipt = await tx1.wait();
+
+        const eth_out = getEventValue(tx1_receipt, 2);
+        const token_out = getEventValue(tx1_receipt, 3);
+
+        console.log("\t", " 💵 User's new $BAL balance:", ethers.utils.formatEther(userBallonsBalanceAfter));
+        console.log(
+          "\t",
+          " 🎈 Expecting the balance to have increased by 1",
+          ethers.utils.formatEther(userBallonsBalanceAfter),
+        );
+        expect(userBallonsBalance, "User $BAL balance shoud increase").to.equal(
+          userBallonsBalanceAfter.sub(ethers.utils.parseEther("1")),
+        );
+
+        console.log("\t", " 🔽 Expecting the Eth withdrawn emit to be 1...");
+        expect(eth_out, "ethWithdrawn incorrect in emit").to.be.equal(ethers.utils.parseEther("1"));
+        console.log("\t", " 🔽 Expecting the $BAL withdrawn emit to be 1...");
+        expect(token_out, "tokenAmount incorrect in emit").to.be.equal(ethers.utils.parseEther("1"));
+      });
+
+      it("Should revert if sender does not have enough liqudity", async function () {
+        console.log("\t", " ✋ Expecting withdraw to revert when there is not enough liquidity...");
+        await expect(dexContract.withdraw(ethers.utils.parseEther("100"))).to.be.reverted;
+      });
+
+      it("Should decrease total liquidity", async function () {
+        const totalLpBefore = await dexContract.totalLiquidity();
+        console.log("\t", " ⚖️ Initial liquidity:", ethers.utils.formatEther(totalLpBefore));
+        console.log("\t", " 📞 Calling withdraw with 1 Eth...");
+        const txWithdraw = await dexContract.withdraw(ethers.utils.parseEther("1"));
+        const totalLpAfter = await dexContract.totalLiquidity();
+        console.log("\t", " ⚖️ Final liquidity:", ethers.utils.formatEther(totalLpAfter));
+        const txWithdraw_receipt = await txWithdraw.wait();
+        const liquidityBurned = getEventValue(txWithdraw_receipt, 2);
+        console.log("\t", " 🔼 Emitted liquidity removed:", ethers.utils.formatEther(liquidityBurned));
+
+        expect(totalLpAfter, "Emitted incorrect liquidity amount burned").to.be.equal(
+          totalLpBefore.sub(liquidityBurned),
+        );
+        expect(totalLpBefore, "Emitted total liquidity should decrease").to.be.above(totalLpAfter);
+      });
+
+      it("Should emit event LiquidityWithdrawn when withdraw() called", async function () {
+        await expect(
+          dexContract.withdraw(ethers.utils.parseEther("1.5")),
+          "Make sure you emit the LiquidityRemoved event correctly",
+        )
+          .to.emit(dexContract, "LiquidityRemoved")
+          .withArgs(
+            deployer.address,
+            ethers.utils.parseEther("1.5"),
+            ethers.utils.parseEther("1.5"),
+            ethers.utils.parseEther("1.5"),
+          );
+      });
+    });
+  });
+  // ----------------- END OF CHECKPOINT 5 -----------------
 });


### PR DESCRIPTION
### Description : 

Updated the test to match auto grader test so that people can run `yarn test` locally to see if it pass locally before submitting 🙌

--- 

I found that in SE-1 we are providing solution in repo here -> https://github.com/scaffold-eth/scaffold-eth-challenges/tree/challenge-4-dex/Solutions

Should we add similar solution code here too ? What do you all think ? 

Here is the solution code  : 

<details>
<summary>
Solution Code
</summary>

```
pragma solidity >=0.8.0 <0.9.0;
// SPDX-License-Identifier: MIT

import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

/**
 * @title DEX
 * @author stevepham.eth and m00npapi.eth
 * @notice this is a single token pair reserves DEX, ref: "Scaffold-ETH Challenge 4" as per https://speedrunethereum.com/, README.md and full branch (front-end) made with lots of inspiration from pre-existing example repos in scaffold-eth organization.
 */
contract DEX {
	/* ========== GLOBAL VARIABLES ========== */

	uint256 public totalLiquidity; //total amount of liquidity provider tokens (LPTs) minted (NOTE: that LPT "price" is tied to the ratio, and thus price of the assets within this AMM)
	mapping(address => uint256) public liquidity; //liquidity of each depositor
	IERC20 token; //instantiates the imported contract

	/* ========== EVENTS ========== */

	/**
	 * @notice Emitted when ethToToken() swap transacted
	 */
	event EthToTokenSwap(
		address swapper,
		uint256 tokenOutput,
		uint256 ethInput
	);

	/**
	 * @notice Emitted when tokenToEth() swap transacted
	 */
	event TokenToEthSwap(
		address swapper,
		uint256 tokensInput,
		uint256 ethOutput
	);

	/**
	 * @notice Emitted when liquidity provided to DEX and mints LPTs.
	 */
	event LiquidityProvided(
		address liquidityProvider,
		uint256 tokensInput,
		uint256 ethInput,
		uint256 liquidityMinted
	);

	/**
	 * @notice Emitted when liquidity removed from DEX and decreases LPT count within DEX.
	 */
	event LiquidityRemoved(
		address liquidityRemover,
		uint256 tokensOutput,
		uint256 ethOutput,
		uint256 liquidityWithdrawn
	);

	/* ========== CONSTRUCTOR ========== */

	constructor(address token_addr) {
		token = IERC20(token_addr); //specifies the token address that will hook into the interface and be used through the variable 'token'
	}

	/* ========== MUTATIVE FUNCTIONS ========== */

	/**
	 * @notice initializes amount of tokens that will be transferred to the DEX itself from the erc20 contract mintee (and only them based on how Balloons.sol is written). Loads contract up with both ETH and Balloons.
	 * @param tokens amount to be transferred to DEX
	 * @return totalLiquidity is the number of LPTs minting as a result of deposits made to DEX contract
	 * NOTE: since ratio is 1:1, this is fine to initialize the totalLiquidity (wrt to balloons) as equal to eth balance of contract.
	 */
	function init(uint256 tokens) public payable returns (uint256) {
		require(totalLiquidity == 0, "DEX: init - already has liquidity");
		totalLiquidity = address(this).balance;
		liquidity[msg.sender] = totalLiquidity;
		require(
			token.transferFrom(msg.sender, address(this), tokens),
			"DEX: init - transfer did not transact"
		);
		return totalLiquidity;
	}

	/**
	 * @notice returns yOutput, or yDelta for xInput (or xDelta)
	 */
	function price(
		uint256 xInput,
		uint256 xReserves,
		uint256 yReserves
	) public pure returns (uint256 yOutput) {
		uint256 xInputWithFee = xInput * 997;
		uint256 numerator = xInputWithFee * yReserves;
		uint256 denominator = (xReserves * 1000) + xInputWithFee;
		return (numerator / denominator);
	}

	/**
	 * @notice returns liquidity for a user. Note this is notneeded typically due to the `liquidity()` mapping variable being public and having a getter as a result. This is left though as it is used within the front end code (App.jsx).
	 */
	function getLiquidity(address lp) public view returns (uint256) {
		return liquidity[lp];
	}

	/**
	 * @notice sends Ether to DEX in exchange for $BAL
	 */
	function ethToToken() public payable returns (uint256 tokenOutput) {
		require(msg.value > 0, "cannot swap 0 ETH");
		uint256 ethReserve = address(this).balance - msg.value;
		uint256 token_reserve = token.balanceOf(address(this));
		uint256 _tokenOutput = price(msg.value, ethReserve, token_reserve);

		require(
			token.transfer(msg.sender, _tokenOutput),
			"ethToToken(): reverted swap."
		);
		emit EthToTokenSwap(msg.sender, _tokenOutput, msg.value);
		return tokenOutput;
	}

	/**
	 * @notice sends $BAL tokens to DEX in exchange for Ether
	 */
	function tokenToEth(uint256 tokenInput) public returns (uint256 ethOutput) {
		require(tokenInput > 0, "cannot swap 0 tokens");
		uint256 token_reserve = token.balanceOf(address(this));
		uint256 _ethOutput = price(
			tokenInput,
			token_reserve,
			address(this).balance
		);
		require(
			token.transferFrom(msg.sender, address(this), tokenInput),
			"tokenToEth(): reverted swap."
		);
		(bool sent, ) = msg.sender.call{ value: _ethOutput }("");
		require(sent, "tokenToEth: revert in transferring eth to you!");
		emit TokenToEthSwap(msg.sender, _ethOutput, tokenInput);
		return _ethOutput;
	}

	/**
	 * @notice allows deposits of $BAL and $ETH to liquidity pool
	 * NOTE: parameter is the msg.value sent with this function call. That amount is used to determine the amount of $BAL needed as well and taken from the depositor.
	 * NOTE: user has to make sure to give DEX approval to spend their tokens on their behalf by calling approve function prior to this function call.
	 * NOTE: Equal parts of both assets will be removed from the user's wallet with respect to the price outlined by the AMM.
	 */
	function deposit() public payable returns (uint256 tokensDeposited) {
		require(msg.value > 0, "Must send value when depositing");
		uint256 ethReserve = address(this).balance - msg.value;
		uint256 tokenReserve = token.balanceOf(address(this));
		uint256 tokenDeposit;

		tokenDeposit = ((msg.value * tokenReserve) / ethReserve) + 1;
		uint256 liquidityMinted = (msg.value * totalLiquidity) / ethReserve;
		liquidity[msg.sender] += liquidityMinted;
		totalLiquidity += liquidityMinted;

		require(token.transferFrom(msg.sender, address(this), tokenDeposit));
		emit LiquidityProvided(
			msg.sender,
			liquidityMinted,
			msg.value,
			tokenDeposit
		);
		return tokenDeposit;
	}

	/**
	 * @notice allows withdrawal of $BAL and $ETH from liquidity pool
	 * NOTE: with this current code, the msg caller could end up getting very little back if the liquidity is super low in the pool. I guess they could see that with the UI.
	 */
	function withdraw(
		uint256 amount
	) public returns (uint256 eth_amount, uint256 token_amount) {
		require(
			liquidity[msg.sender] >= amount,
			"withdraw: sender does not have enough liquidity to withdraw."
		);
		uint256 ethReserve = address(this).balance;
		uint256 tokenReserve = token.balanceOf(address(this));
		uint256 ethWithdrawn;

		ethWithdrawn = (amount * ethReserve) / totalLiquidity;

		uint256 tokenAmount = (amount * tokenReserve) / totalLiquidity;
		liquidity[msg.sender] -= amount;
		totalLiquidity -= amount;
		(bool sent, ) = payable(msg.sender).call{ value: ethWithdrawn }("");
		require(sent, "withdraw(): revert in transferring eth to you!");
		require(token.transfer(msg.sender, tokenAmount));
		emit LiquidityRemoved(msg.sender, amount, ethWithdrawn, tokenAmount);
		return (ethWithdrawn, tokenAmount);
	}
}


```

</details>