### PR TITLE
fix: stake events frontend

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventHistory.ts
@@ -101,8 +101,16 @@ export const useScaffoldEventHistory = <
   ]);
 
   return {
-    data: events,
+    data: events?.map(addIndexedArgsToEvent),
     isLoading: isLoading,
     error: error,
   };
+};
+
+export const addIndexedArgsToEvent = (event: any) => {
+  if (event.args && !Array.isArray(event.args)) {
+    return { ...event, args: { ...event.args, ...Object.values(event.args) } };
+  }
+
+  return event;
 };

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventSubscriber.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventSubscriber.ts
@@ -1,7 +1,7 @@
 import { Abi, ExtractAbiEventNames } from "abitype";
 import { Log } from "viem";
 import { useContractEvent } from "wagmi";
-import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
+import { addIndexedArgsToEvent, useDeployedContractInfo } from "~~/hooks/scaffold-eth";
 import { getTargetNetwork } from "~~/utils/scaffold-eth";
 import { ContractAbi, ContractName, UseScaffoldEventConfig } from "~~/utils/scaffold-eth/contract";
 
@@ -22,11 +22,15 @@ export const useScaffoldEventSubscriber = <
 }: UseScaffoldEventConfig<TContractName, TEventName>) => {
   const { data: deployedContractData } = useDeployedContractInfo(contractName);
 
+  const addInexedArgsToLogs = (logs: Log[]) => logs.map(addIndexedArgsToEvent);
+  const listenerWithIndexedArgs = (logs: Log[]) =>
+    listener(addInexedArgsToLogs(logs) as Parameters<typeof listener>[0]);
+
   return useContractEvent({
     address: deployedContractData?.address,
     abi: deployedContractData?.abi as Abi,
     chainId: getTargetNetwork().id,
-    listener: listener as (logs: Log[]) => void,
+    listener: listenerWithIndexedArgs,
     eventName,
   });
 };

--- a/packages/nextjs/pages/stakings.tsx
+++ b/packages/nextjs/pages/stakings.tsx
@@ -47,9 +47,9 @@ const Stakings: NextPage = () => {
                   return (
                     <tr key={index}>
                       <td>
-                        <Address address={event.args?.staker} />
+                        <Address address={event.args?.[0]} />
                       </td>
-                      <td>{event.args?.amount && formatEther(event.args?.amount)} ETH</td>
+                      <td>{event.args?.[1] && formatEther(event.args?.[1])} ETH</td>
                     </tr>
                   );
                 })


### PR DESCRIPTION
Events table doesn't work if when creating a contract, `Stake` event parameters aren't named `staker` and `amount`. In base Challenge contract params of `Stake` event has no names, also in [Readme](https://github.com/scaffold-eth/se-2-challenges/blob/challenge-1-decentralized-staking/README.md?plain=1#L9) too.

So we need to use [0] and [1] args by default.