### PR TITLE
stack roll events and dice roll content on small screen

### DIFF
--- a/packages/nextjs/pages/dice.tsx
+++ b/packages/nextjs/pages/dice.tsx
@@ -160,10 +160,12 @@ const DiceGame: NextPage = () => {
     <>
       <MetaHeader />
       <div className="py-10 px-10">
-        <div className="grid grid-cols-3">
-          <RollEvents rolls={rolls} />
+        <div className="grid grid-cols-3 max-md:grid-cols-1">
+          <div className="max-md:row-start-2">
+            <RollEvents rolls={rolls} />
+          </div>
 
-          <div className="flex flex-col items-center pt-4">
+          <div className="flex flex-col items-center pt-4 max-md:row-start-1">
             <div className="flex w-full justify-center">
               <span className="text-xl"> Roll a 0, 1, or 2 to win the prize! </span>
             </div>
@@ -230,7 +232,9 @@ const DiceGame: NextPage = () => {
             </div>
           </div>
 
-          <WinnerEvents winners={winners} />
+          <div className="max-md:row-start-3">
+            <WinnerEvents winners={winners} />
+          </div>
         </div>
       </div>
     </>

--- a/packages/nextjs/pages/dice.tsx
+++ b/packages/nextjs/pages/dice.tsx
@@ -160,12 +160,12 @@ const DiceGame: NextPage = () => {
     <>
       <MetaHeader />
       <div className="py-10 px-10">
-        <div className="grid grid-cols-3 max-md:grid-cols-1">
-          <div className="max-md:row-start-2">
+        <div className="grid grid-cols-3 max-lg:grid-cols-1">
+          <div className="max-lg:row-start-2">
             <RollEvents rolls={rolls} />
           </div>
 
-          <div className="flex flex-col items-center pt-4 max-md:row-start-1">
+          <div className="flex flex-col items-center pt-4 max-lg:row-start-1">
             <div className="flex w-full justify-center">
               <span className="text-xl"> Roll a 0, 1, or 2 to win the prize! </span>
             </div>
@@ -232,7 +232,7 @@ const DiceGame: NextPage = () => {
             </div>
           </div>
 
-          <div className="max-md:row-start-3">
+          <div className="max-lg:row-start-3">
             <WinnerEvents winners={winners} />
           </div>
         </div>


### PR DESCRIPTION
### Why
On small screen dice page shows roll event, winner event and game ui in single row, making events UI to overlap with center game UI. 

### What
On small screen dice page will show Game UI on top and then roll event and then winner event in stack form. 

### How
When screen size is small reduce the grid column to 1 and rearrange Game UI, Roll Event and Winner UI with grid's start-row property.

![Screenshot from 2023-09-30 16-35-35](https://github.com/scaffold-eth/se-2-challenges/assets/17810719/7c7dee90-9e64-4285-8dfa-3355ee591412)

![Screenshot from 2023-09-30 16-33-58](https://github.com/scaffold-eth/se-2-challenges/assets/17810719/6b58c66d-0520-43d3-b333-5f11ced933a3)

