### PR TITLE
don't use custom light blue color for copy icon

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -101,10 +101,7 @@ export const Address = ({ address, disableAddressLink, format, size = "base" }: 
         </a>
       )}
       {addressCopied ? (
-        <CheckCircleIcon
-          className="ml-1.5 text-xl font-normal text-sky-600 h-5 w-5 cursor-pointer"
-          aria-hidden="true"
-        />
+        <CheckCircleIcon className="ml-1.5 text-xl font-normal h-5 w-5 cursor-pointer" aria-hidden="true" />
       ) : (
         <CopyToClipboard
           text={address}
@@ -115,10 +112,7 @@ export const Address = ({ address, disableAddressLink, format, size = "base" }: 
             }, 800);
           }}
         >
-          <DocumentDuplicateIcon
-            className="ml-1.5 text-xl font-normal text-sky-600 h-5 w-5 cursor-pointer"
-            aria-hidden="true"
-          />
+          <DocumentDuplicateIcon className="ml-1.5 text-xl font-normal h-5 w-5 cursor-pointer" aria-hidden="true" />
         </CopyToClipboard>
       )}
     </div>


### PR DESCRIPTION
### Why
Currently copy icon of address component uses custom light blue color but this cause issue when some custom background is used. The issue is icon not clearly visible against some background.

### What
Change copy icon of address component to not use custom icon color but keep it default so that it auto adjust against background.

### How
Remove custom tailwind css text property.

Test method - add a new address component in debug tab under contact variable so see different against 3 different background.

#### What to Notice - 3rd address copy button in dark mode before and after

#### Before Light
![Screenshot from Screencast from 02-10-23 11:18:02 AM IST webm - 1](https://github.com/scaffold-eth/se-2-challenges/assets/17810719/030dfaa0-8be6-445e-9ba9-513273a857f1)

#### After Light
![Screenshot from Screencast from 02-10-23 11:17:03 AM IST webm_1](https://github.com/scaffold-eth/se-2-challenges/assets/17810719/9e897aa7-4eb1-40e0-9f4c-d44f1ee828d1)

#### Before Dark
![Screenshot from Screencast from 02-10-23 11:17:51 AM IST webm - 3](https://github.com/scaffold-eth/se-2-challenges/assets/17810719/a23ee9e8-0123-44f4-9568-8f167fcbd494)

#### After Dark
![Screenshot from Screencast from 02-10-23 11:17:17 AM IST webm](https://github.com/scaffold-eth/se-2-challenges/assets/17810719/cce85c94-028a-469d-a54f-57dfb756504b)
