### PR TITLE
Challenge 4: Guard against vulnerability with the deposit function

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,11 +310,12 @@ Let’s create two new functions that let us deposit and withdraw liquidity. How
         // 💡 Discussion on adding 1 wei at end of calculation   ^
         // -> https://t.me/c/1655715571/106
 
+        require(token.transferFrom(msg.sender, address(this), tokenDeposit));
         uint256 liquidityMinted = msg.value * totalLiquidity / ethReserve;
         liquidity[msg.sender] += liquidityMinted;
         totalLiquidity += liquidityMinted;
 
-        require(token.transferFrom(msg.sender, address(this), tokenDeposit));
+
         emit LiquidityProvided(msg.sender, tokenDeposit, msg.value, liquidityMinted);
         return tokenDeposit;
     }


### PR DESCRIPTION
Fixes #105 

The provided solution code for the `deposit` function updates the `liquidity` mapping before transferring $BAL tokens to the DEX

I think it would be better to transfer the tokens from the caller of `deposit()` before updating the `liquidity` mapping in order to protect the DEX contract from being drained via reentrancy attack