### PR TITLE
Fix test on token liquidity added to DEX

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Let’s create two new functions that let us deposit and withdraw liquidity. How
         totalLiquidity += liquidityMinted;
 
         require(token.transferFrom(msg.sender, address(this), tokenDeposit));
-        emit LiquidityProvided(msg.sender, tokenDeposit, msg.value, liquidityMinted);
+        emit LiquidityProvided(msg.sender, liquidityMinted, msg.value, tokenDeposit);
         return tokenDeposit;
     }
 
@@ -333,7 +333,7 @@ Let’s create two new functions that let us deposit and withdraw liquidity. How
         (bool sent, ) = payable(msg.sender).call{ value: ethWithdrawn }("");
         require(sent, "withdraw(): revert in transferring eth to you!");
         require(token.transfer(msg.sender, tokenAmount));
-        emit LiquidityRemoved(msg.sender, tokenAmount, ethWithdrawn, amount);
+        emit LiquidityRemoved(msg.sender, amount, ethWithdrawn, tokenAmount);
         return (ethWithdrawn, tokenAmount);
     }
 

--- a/packages/hardhat/contracts/DEX.sol
+++ b/packages/hardhat/contracts/DEX.sol
@@ -12,93 +12,109 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  * NOTE: functions outlined here are what work with the front end of this challenge. Also return variable names need to be specified exactly may be referenced (It may be helpful to cross reference with front-end code function calls).
  */
 contract DEX {
-    /* ========== GLOBAL VARIABLES ========== */
+	/* ========== GLOBAL VARIABLES ========== */
 
-    IERC20 token; //instantiates the imported contract
+	IERC20 token; //instantiates the imported contract
 
-    /* ========== EVENTS ========== */
+	/* ========== EVENTS ========== */
 
-    /**
-     * @notice Emitted when ethToToken() swap transacted
-     */
-    event EthToTokenSwap(address swapper, uint256 tokenOutput, uint256 ethInput);
+	/**
+	 * @notice Emitted when ethToToken() swap transacted
+	 */
+	event EthToTokenSwap(
+		address swapper,
+		uint256 tokenOutput,
+		uint256 ethInput
+	);
 
-    /**
-     * @notice Emitted when tokenToEth() swap transacted
-     */
-    event TokenToEthSwap(address swapper, uint256 tokensInput, uint256 ethOutput);
+	/**
+	 * @notice Emitted when tokenToEth() swap transacted
+	 */
+	event TokenToEthSwap(
+		address swapper,
+		uint256 tokensInput,
+		uint256 ethOutput
+	);
 
-    /**
-     * @notice Emitted when liquidity provided to DEX and mints LPTs.
-     */
-    event LiquidityProvided(address liquidityProvider, uint256 tokensInput, uint256 ethInput, uint256 liquidityMinted);
+	/**
+	 * @notice Emitted when liquidity provided to DEX and mints LPTs.
+	 */
+	event LiquidityProvided(
+		address liquidityProvider,
+		uint256 liquidityMinted,
+		uint256 ethInput,
+		uint256 tokensInput
+	);
 
-    /**
-     * @notice Emitted when liquidity removed from DEX and decreases LPT count within DEX.
-     */
-    event LiquidityRemoved(
-        address liquidityRemover,
-        uint256 tokensOutput,
-        uint256 ethOutput,
-        uint256 liquidityWithdrawn
-    );
+	/**
+	 * @notice Emitted when liquidity removed from DEX and decreases LPT count within DEX.
+	 */
+	event LiquidityRemoved(
+		address liquidityRemover,
+		uint256 liquidityWithdrawn,
+		uint256 tokensOutput,
+		uint256 ethOutput
+	);
 
-    /* ========== CONSTRUCTOR ========== */
+	/* ========== CONSTRUCTOR ========== */
 
-    constructor(address token_addr) public {
-        token = IERC20(token_addr); //specifies the token address that will hook into the interface and be used through the variable 'token'
-    }
+	constructor(address token_addr) {
+		token = IERC20(token_addr); //specifies the token address that will hook into the interface and be used through the variable 'token'
+	}
 
-    /* ========== MUTATIVE FUNCTIONS ========== */
+	/* ========== MUTATIVE FUNCTIONS ========== */
 
-    /**
-     * @notice initializes amount of tokens that will be transferred to the DEX itself from the erc20 contract mintee (and only them based on how Balloons.sol is written). Loads contract up with both ETH and Balloons.
-     * @param tokens amount to be transferred to DEX
-     * @return totalLiquidity is the number of LPTs minting as a result of deposits made to DEX contract
-     * NOTE: since ratio is 1:1, this is fine to initialize the totalLiquidity (wrt to balloons) as equal to eth balance of contract.
-     */
-    function init(uint256 tokens) public payable returns (uint256) {}
+	/**
+	 * @notice initializes amount of tokens that will be transferred to the DEX itself from the erc20 contract mintee (and only them based on how Balloons.sol is written). Loads contract up with both ETH and Balloons.
+	 * @param tokens amount to be transferred to DEX
+	 * @return totalLiquidity is the number of LPTs minting as a result of deposits made to DEX contract
+	 * NOTE: since ratio is 1:1, this is fine to initialize the totalLiquidity (wrt to balloons) as equal to eth balance of contract.
+	 */
+	function init(uint256 tokens) public payable returns (uint256) {}
 
-    /**
-     * @notice returns yOutput, or yDelta for xInput (or xDelta)
-     * @dev Follow along with the [original tutorial](https://medium.com/@austin_48503/%EF%B8%8F-minimum-viable-exchange-d84f30bd0c90) Price section for an understanding of the DEX's pricing model and for a price function to add to your contract. You may need to update the Solidity syntax (e.g. use + instead of .add, * instead of .mul, etc). Deploy when you are done.
-     */
-    function price(
-        uint256 xInput,
-        uint256 xReserves,
-        uint256 yReserves
-    ) public pure returns (uint256 yOutput) {}
+	/**
+	 * @notice returns yOutput, or yDelta for xInput (or xDelta)
+	 * @dev Follow along with the [original tutorial](https://medium.com/@austin_48503/%EF%B8%8F-minimum-viable-exchange-d84f30bd0c90) Price section for an understanding of the DEX's pricing model and for a price function to add to your contract. You may need to update the Solidity syntax (e.g. use + instead of .add, * instead of .mul, etc). Deploy when you are done.
+	 */
+	function price(
+		uint256 xInput,
+		uint256 xReserves,
+		uint256 yReserves
+	) public pure returns (uint256 yOutput) {}
 
-    /**
-     * @notice returns liquidity for a user.
-     * NOTE: this is not needed typically due to the `liquidity()` mapping variable being public and having a getter as a result. This is left though as it is used within the front end code (App.jsx).
-     * NOTE: if you are using a mapping liquidity, then you can use `return liquidity[lp]` to get the liquidity for a user.
-     * NOTE: if you will be submitting the challenge make sure to implement this function as it is used in the tests.
-     */
-    function getLiquidity(address lp) public view returns (uint256) {}
+	/**
+	 * @notice returns liquidity for a user.
+	 * NOTE: this is not needed typically due to the `liquidity()` mapping variable being public and having a getter as a result. This is left though as it is used within the front end code (App.jsx).
+	 * NOTE: if you are using a mapping liquidity, then you can use `return liquidity[lp]` to get the liquidity for a user.
+	 * NOTE: if you will be submitting the challenge make sure to implement this function as it is used in the tests.
+	 */
+	function getLiquidity(address lp) public view returns (uint256) {}
 
-    /**
-     * @notice sends Ether to DEX in exchange for $BAL
-     */
-    function ethToToken() public payable returns (uint256 tokenOutput) {}
+	/**
+	 * @notice sends Ether to DEX in exchange for $BAL
+	 */
+	function ethToToken() public payable returns (uint256 tokenOutput) {}
 
-    /**
-     * @notice sends $BAL tokens to DEX in exchange for Ether
-     */
-    function tokenToEth(uint256 tokenInput) public returns (uint256 ethOutput) {}
+	/**
+	 * @notice sends $BAL tokens to DEX in exchange for Ether
+	 */
+	function tokenToEth(
+		uint256 tokenInput
+	) public returns (uint256 ethOutput) {}
 
-    /**
-     * @notice allows deposits of $BAL and $ETH to liquidity pool
-     * NOTE: parameter is the msg.value sent with this function call. That amount is used to determine the amount of $BAL needed as well and taken from the depositor.
-     * NOTE: user has to make sure to give DEX approval to spend their tokens on their behalf by calling approve function prior to this function call.
-     * NOTE: Equal parts of both assets will be removed from the user's wallet with respect to the price outlined by the AMM.
-     */
-    function deposit() public payable returns (uint256 tokensDeposited) {}
+	/**
+	 * @notice allows deposits of $BAL and $ETH to liquidity pool
+	 * NOTE: parameter is the msg.value sent with this function call. That amount is used to determine the amount of $BAL needed as well and taken from the depositor.
+	 * NOTE: user has to make sure to give DEX approval to spend their tokens on their behalf by calling approve function prior to this function call.
+	 * NOTE: Equal parts of both assets will be removed from the user's wallet with respect to the price outlined by the AMM.
+	 */
+	function deposit() public payable returns (uint256 tokensDeposited) {}
 
-    /**
-     * @notice allows withdrawal of $BAL and $ETH from liquidity pool
-     * NOTE: with this current code, the msg caller could end up getting very little back if the liquidity is super low in the pool. I guess they could see that with the UI.
-     */
-    function withdraw(uint256 amount) public returns (uint256 eth_amount, uint256 token_amount) {}
+	/**
+	 * @notice allows withdrawal of $BAL and $ETH from liquidity pool
+	 * NOTE: with this current code, the msg caller could end up getting very little back if the liquidity is super low in the pool. I guess they could see that with the UI.
+	 */
+	function withdraw(
+		uint256 amount
+	) public returns (uint256 eth_amount, uint256 token_amount) {}
 }
-

--- a/packages/hardhat/test/Challenge4.ts
+++ b/packages/hardhat/test/Challenge4.ts
@@ -302,7 +302,7 @@ describe("🚩 Challenge 4: ⚖️ 🪙 DEX", () => {
           "Check the order of the values when emitting LiquidityProvided: msg.sender, liquidityMinted, msg.value, tokenDeposit",
         )
           .to.emit(dexContract, "LiquidityProvided")
-          .withArgs(anyValue, ethers.utils.parseEther("5"), ethers.utils.parseEther("5"), anyValue);
+          .withArgs(anyValue, ethers.utils.parseEther("5").add("1"), ethers.utils.parseEther("5"), anyValue);
         const liquidity_end = await dexContract.totalLiquidity();
         console.log(
           "\t",

--- a/packages/hardhat/test/Challenge4.ts
+++ b/packages/hardhat/test/Challenge4.ts
@@ -302,7 +302,7 @@ describe("🚩 Challenge 4: ⚖️ 🪙 DEX", () => {
           "Check the order of the values when emitting LiquidityProvided: msg.sender, liquidityMinted, msg.value, tokenDeposit",
         )
           .to.emit(dexContract, "LiquidityProvided")
-          .withArgs(anyValue, ethers.utils.parseEther("5").add("1"), ethers.utils.parseEther("5"), anyValue);
+          .withArgs(anyValue, ethers.utils.parseEther("5"), ethers.utils.parseEther("5"), anyValue);
         const liquidity_end = await dexContract.totalLiquidity();
         console.log(
           "\t",


### PR DESCRIPTION
## What

Fixed the Liquidity provided test by adding 1 wei unit to the expected number of tokens deposited.

## Why

When calculating the tokens added when depositing liquidity, we add 1 wei as a safeguard. As the solution code demonstrates in Checkpoint 5 here: https://speedrunethereum.com/challenge/minimum-viable-exchange

```
        tokenDeposit = (msg.value * tokenReserve / ethReserve) + 1;
        // 💡 Discussion on adding 1 wei at end of calculation   ^
        // -> https://t.me/c/1655715571/106

```
However, adding 1 as above breaks the test that checks the `LiquidityProvided` event for the added tokens.

![err](https://github.com/scaffold-eth/se-2-challenges/assets/731798/d7c42615-445f-4b03-9743-0befbc53a773)

Fixed the test by adding one wei to the expected number of tokens deposited.

## Steps to Reproduce

- Clone the repo
- Checkout the branch `challenge-4-dex`
- Copy all the solution code from the README into DEX.sol
- Implement the `getLiquidity` getter method
- Run `yarn test`

The test will give the test error shown above.

Also reported in the DEX challenge group [here](https://t.me/c/1655715571/5065)

