### PR TITLE
Add a link to the alpha version of Ch0 assistant at Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 🌟 The final deliverable is an app that lets users purchase and transfer NFTs. Deploy your contracts to a testnet, then build and upload your app to a public web server. Submit the url on [SpeedRunEthereum.com](https://speedrunethereum.com)!
 
+🤖 If you have any question during your Challenge, you can try out the [Challenge AI assistant](https://scaffold-eth-assistant.streamlit.app/), and get answers to your Challenge/Scaffold-ETH questions.
+
 💬 Meet other builders working on this challenge and get help in the [Challenge 0 Telegram](https://t.me/+Y2vqXZZ_pEFhMGMx)!
 
 ## Checkpoint 0: 📦 Environment 📚
@@ -211,8 +213,6 @@ yarn verify --network sepolia
 
 ---
 
-> 🤖 If you have Chat GPT Plus account, you can try out [GPT Challenge 0 assistant](https://chat.openai.com/g/g-gk1PO5LNr-sre-challenge-0-assistant-alpha-version) and get answers for your questions about this Challenge.
->
 > ⭐ Please share your feedback with us in the [Challenge 0 Telegram](https://t.me/+Y2vqXZZ_pEFhMGMx) if you have a chance to try the GPT assistant!
 
 > 🏃 Head to your next challenge [here](https://github.com/scaffold-eth/se-2-challenges).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 💬 Meet other builders working on this challenge and get help in the [Challenge 0 Telegram](https://t.me/+Y2vqXZZ_pEFhMGMx)!
 
+🤖 If you have any question during your Challenge, you can try out the [Challenge AI assistant](https://scaffold-eth-assistant.streamlit.app/), and get answers to your Challenge/Scaffold-ETH questions. Please reach us in Telegram if something feels wrong!
+
 ## Checkpoint 0: 📦 Environment 📚
 
 Before you begin, you need to install the following tools:
@@ -212,8 +214,6 @@ yarn verify --network sepolia
 (It can take a while before they show up, but here is an example:) https://testnets.opensea.io/assets/sepolia/0x17ed03686653917efa2194a5252c5f0a4f3dc49c/2
 
 ---
-
-> ⭐ Please share your feedback with us in the [Challenge 0 Telegram](https://t.me/+Y2vqXZZ_pEFhMGMx) if you have a chance to try the GPT assistant!
 
 > 🏃 Head to your next challenge [here](https://github.com/scaffold-eth/se-2-challenges).
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ yarn verify --network sepolia
 
 ---
 
+> 🤖 If you have Chat GPT Plus account, you can try out [GPT Challenge 0 assistant](https://chat.openai.com/g/g-gk1PO5LNr-sre-challenge-0-assistant-alpha-version) and get answers for your questions about this Challenge.
+>
+> ⭐ Please share your feedback with us in the [Challenge 0 Telegram](https://t.me/+Y2vqXZZ_pEFhMGMx) if you have a chance to try the GPT assistant!
+
 > 🏃 Head to your next challenge [here](https://github.com/scaffold-eth/se-2-challenges).
 
 > 💬 Problems, questions, comments on the stack? Post them to the [🏗 scaffold-eth developers chat](https://t.me/joinchat/F7nCRK3kI93PoCOk)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 🌟 The final deliverable is an app that lets users purchase and transfer NFTs. Deploy your contracts to a testnet, then build and upload your app to a public web server. Submit the url on [SpeedRunEthereum.com](https://speedrunethereum.com)!
 
-🤖 If you have any question during your Challenge, you can try out the [Challenge AI assistant](https://scaffold-eth-assistant.streamlit.app/), and get answers to your Challenge/Scaffold-ETH questions.
-
 💬 Meet other builders working on this challenge and get help in the [Challenge 0 Telegram](https://t.me/+Y2vqXZZ_pEFhMGMx)!
 
 🤖 If you have any question during your Challenge, you can try out the [Challenge AI assistant](https://scaffold-eth-assistant.streamlit.app/), and get answers to your Challenge/Scaffold-ETH questions. Please reach us in Telegram if something feels wrong!


### PR DESCRIPTION
## Context

Last couple of weeks I've been researching different approaches to create an assistant to help new SRE users through their Challenges. I've tried:

- __Fine tunning a model with SE-2 docs, Challenge 0 Readme and TG Challenge 0 Q/A.__
Didn't work at all, probably didn't do it right because results were terrible. Could try again in the future with a different base model, but this system requires to develop also a layer to interact with the users (web, telegram bot)

- __Using a local AI (PrivateGPT) as a solution to privacy concerns, giving it contexts (SE-2 docs, Challenge 0 Readme and TG Challenge 0 Q/A).__
You don't share all your info and the user prompts and answers with a 3rd party, and there is no limit of context to provide, but I don't see an easy solution to open it to the users nor add it as telegram bot

- __Create a GPT with Chat GPT__
Worked the best, has no cost to us or to the user, but requires to have Chat GPT Plus in order to use it. Has a familiar interface for Chat GPT users.

- __Create an assistant with Chat GPT.__
Same results as a GPT, can be integrated as a telegram bot easily with their API, but the cost can be elevated for us, since this alpha version has a lot of context (many doc files), and Open AI charges per tokens used. Could be a future iteration if we see this useful and want to open it to 100% of potential users.

For this GPT-Ch0 Alpha Assistant I'm providing this context:
- All SE-2 doc files, as independant .md files
- Challenge 0 Readme as .md file
- Q/A from Challenge 0 Telegram group, only using questions and answers post SE-2 migration, fetched manually.
[Ch0-Telegram-QA.txt](https://github.com/scaffold-eth/se-2-challenges/files/14311566/Ch0-Telegram-QA.txt)


## Proposal
If we see the AI Assistant interesting/useful, I would follow this approach:

1. __Add this GPT Ch0 Alpha Assistant to the Challenge 0 readme with this PR__, and try to get some feedback from the next SRE users.

2. After gathering feedback for a few weeks, if it feels useful, we can create the Q/A files for Challenges 1 and 2, and open the GPTs for those Challenges.

3. In the future, if we feel that not many SRE users have Chat GPT Plus, and we feel the assistants are useful for BG, we could setup TG bots with a BG Open AI account and buy some credits for the API.