### PR TITLE
Ch0: Update test for the autograder

### DIFF
--- a/packages/hardhat/test/Challenge0.ts
+++ b/packages/hardhat/test/Challenge0.ts
@@ -19,17 +19,20 @@ describe("🚩 Challenge 0: 🎟 Simple NFT Example 🤓", function () {
 
   describe("YourCollectible", function () {
     const contractAddress = process.env.CONTRACT_ADDRESS;
+
+    let contractArtifact: string;
     if (contractAddress) {
-      it("Should connect to external contract", async function () {
-        myContract = await ethers.getContractAt("YourCollectible", contractAddress);
-        console.log("     🛰 Connected to external contract", myContract.address);
-      });
+      // For the autograder.
+      contractArtifact = `contracts/download-${contractAddress}.sol:YourCollectible`
     } else {
-      it("Should deploy YourCollectible", async function () {
-        const YourCollectible = await ethers.getContractFactory("YourCollectible");
-        myContract = await YourCollectible.deploy();
-      });
+      contractArtifact = "contracts/YourCollectible.sol:YourCollectible";
     }
+
+    it("Should deploy the contract", async function () {
+      const YourCollectible = await ethers.getContractFactory(contractArtifact);
+      myContract = await YourCollectible.deploy();
+      console.log("\t"," 🛰  Contract deployed on", myContract.address);
+    });
 
     describe("mintItem()", function () {
       it("Should be able to mint an NFT", async function () {

--- a/packages/hardhat/test/Challenge0.ts
+++ b/packages/hardhat/test/Challenge0.ts
@@ -1,11 +1,5 @@
 //
-// this script executes when you run 'yarn test'
-//
-// you can also test remote submissions like:
-// CONTRACT_ADDRESS=0x43Ab1FCd430C1f20270C2470f857f7a006117bbb yarn test --network sepolia
-//
-// you can even run mint commands if the tests pass like:
-// yarn test && echo "PASSED" || echo "FAILED"
+// This script executes when you run 'yarn test'
 //
 
 import { ethers } from "hardhat";

--- a/packages/hardhat/test/Challenge0.ts
+++ b/packages/hardhat/test/Challenge0.ts
@@ -17,7 +17,7 @@ describe("🚩 Challenge 0: 🎟 Simple NFT Example 🤓", function () {
     let contractArtifact: string;
     if (contractAddress) {
       // For the autograder.
-      contractArtifact = `contracts/download-${contractAddress}.sol:YourCollectible`
+      contractArtifact = `contracts/download-${contractAddress}.sol:YourCollectible`;
     } else {
       contractArtifact = "contracts/YourCollectible.sol:YourCollectible";
     }
@@ -25,7 +25,7 @@ describe("🚩 Challenge 0: 🎟 Simple NFT Example 🤓", function () {
     it("Should deploy the contract", async function () {
       const YourCollectible = await ethers.getContractFactory(contractArtifact);
       myContract = await YourCollectible.deploy();
-      console.log("\t"," 🛰  Contract deployed on", myContract.address);
+      console.log("\t", " 🛰  Contract deployed on", myContract.address);
     });
 
     describe("mintItem()", function () {


### PR DESCRIPTION
- Contracts are downloaded from the autograder and run locally.
- Had to add the prefix "download", if not getting this (typechain to blame, doesn't like the files starting with numbers.)

![1](https://github.com/scaffold-eth/se-2-challenges/assets/2486142/7c60cf31-f73b-4971-b244-f8377cc34cea)

If doesn't affect the test workflow for the builder, we can merge it.

We need to do this for all the other challenges too. SE-1 tests did this too (e.g. https://github.com/scaffold-eth/scaffold-eth-challenges/blob/challenge-1-decentralized-staking/packages/hardhat/test/challenge_1.js), but not sure why/when we changed it in the SE-2.