### PR TITLE
Enhanced clarity with additional layer of comments to address potential ambiguity

### DIFF
--- a/packages/hardhat/deploy/01_deploy_vendor.ts
+++ b/packages/hardhat/deploy/01_deploy_vendor.ts
@@ -37,9 +37,9 @@ const deployVendor: DeployFunction = async function (hre: HardhatRuntimeEnvironm
   // const vendor = await hre.ethers.getContract<Contract>("Vendor", deployer);
   // const vendorAddress = await vendor.getAddress();
   // // Transfer tokens to Vendor
-  // await yourToken.transfer(vendorAddress, hre.ethers.parseEther("1000"));
+  // // await yourToken.transfer(vendorAddress, hre.ethers.parseEther("1000"));
   // // Transfer contract ownership to your frontend address
-  // await vendor.transferOwnership("**YOUR FRONTEND ADDRESS**");
+  // // await vendor.transferOwnership("**YOUR FRONTEND ADDRESS**");
 };
 
 export default deployVendor;


### PR DESCRIPTION
Within `Checkpoint 2: ⚖️ Vendor 🤖`, the instruction `Edit packages/hardhat/deploy/01_deploy_vendor.js to deploy the Vendor (uncomment Vendor deploy lines).` can cause ambiguity on which exact lines to uncomment.

`Vender deploy lines` may appear to some users as the following lines of code:
```
  // // Deploy Vendor
  // const { deployer } = await hre.getNamedAccounts();
  // const { deploy } = hre.deployments;
  // const yourToken = await hre.ethers.getContract<Contract>("YourToken", deployer);
  // const yourTokenAddress = await yourToken.getAddress();
  // await deploy("Vendor", {
  //   from: deployer,
  //   // Contract constructor arguments
  //   args: [yourTokenAddress],
  //   log: true,
  //   // autoMine: can be passed to the deploy function to make the deployment process faster on local networks by
  //   // automatically mining the contract deployment transaction. There is no effect on live networks.
  //   autoMine: true,
  // });
  // const vendor = await hre.ethers.getContract<Contract>("Vendor", deployer);
  // const vendorAddress = await vendor.getAddress();
  // // Transfer tokens to Vendor
  // await yourToken.transfer(vendorAddress, hre.ethers.parseEther("1000"));
  // // Transfer contract ownership to your frontend address
  // await vendor.transferOwnership("**YOUR FRONTEND ADDRESS**");
  ```
If a user uncomments this entire section, the following 2 lines are also uncommented, although they should remain commented until later within the instructions:
- `await yourToken.transfer(vendorAddress, hre.ethers.parseEther("1000"));`
- `await vendor.transferOwnership("**YOUR FRONTEND ADDRESS**");`

Therefore, the above 2 lines should have an additional layer of comments so that each line is properly uncommented when the user gets to the appropriate instruction:
- `Then, edit deploy/01_deploy_vendor.js to transfer 1000 tokens to vendor address.`
- `In deploy/01_deploy_vendor.js you will need to call transferOwnership() on the Vendor to make your frontend address the owner:`