### PR TITLE
Removed ownable from contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ await yourToken.transfer(
 
 `contract Vendor is Ownable {`
 
-⚠️ You will also need to uncomment the Ownable.sol contract!
+⚠️ You will also need to uncomment the import of Ownable.sol contract!
 
 In `deploy/01_deploy_vendor.js` you will need to call `transferOwnership()` on the `Vendor` to make _your frontend address_ the `owner`:
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ await yourToken.transfer(
 
 `contract Vendor is Ownable {`
 
-⚠️ You will also need to import the Ownable.sol contract!
+⚠️ You will also need to uncomment the Ownable.sol contract!
 
 In `deploy/01_deploy_vendor.js` you will need to call `transferOwnership()` on the `Vendor` to make _your frontend address_ the `owner`:
 

--- a/packages/hardhat/contracts/Vendor.sol
+++ b/packages/hardhat/contracts/Vendor.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.8.4; //Do not change the solidity version as it negativly impacts submission grading
 // SPDX-License-Identifier: MIT
 
-import "@openzeppelin/contracts/access/Ownable.sol";
+// import "@openzeppelin/contracts/access/Ownable.sol";
 import "./YourToken.sol";
 
 contract Vendor {

--- a/packages/hardhat/contracts/Vendor.sol
+++ b/packages/hardhat/contracts/Vendor.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.4; //Do not change the solidity version as it negativly impa
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./YourToken.sol";
 
-contract Vendor is Ownable {
+contract Vendor {
   // event BuyTokens(address buyer, uint256 amountOfETH, uint256 amountOfTokens);
 
   YourToken public yourToken;


### PR DESCRIPTION
Within `Checkpoint 2: ⚖️ Vendor 🤖`, the instruction `Edit Vendor.sol to inherit Ownable` assumes that the Vendor contract isn't already Ownable. Therefore, the Vender contract should not inherit the Ownable contract by default. Instead, the user should update the contract to inherit the Ownable contract when the instruction `Edit Vendor.sol to inherit Ownable` is reached.