### PR TITLE
Wrap api in try catch for chall 0

### DIFF
--- a/packages/nextjs/app/api/ipfs/add/route.ts
+++ b/packages/nextjs/app/api/ipfs/add/route.ts
@@ -1,9 +1,12 @@
 import { ipfsClient } from "~~/utils/simpleNFT/ipfs";
 
 export async function POST(request: Request) {
-  const body = await request.json();
-
-  const res = await ipfsClient.add(JSON.stringify(body));
-
-  return Response.json(res);
+  try {
+    const body = await request.json();
+    const res = await ipfsClient.add(JSON.stringify(body));
+    return Response.json(res);
+  } catch (error) {
+    console.log("Error adding to ipfs", error);
+    return Response.json({ error: "Error adding to ipfs" });
+  }
 }

--- a/packages/nextjs/app/api/ipfs/get-metadata/route.ts
+++ b/packages/nextjs/app/api/ipfs/get-metadata/route.ts
@@ -1,9 +1,12 @@
 import { getNFTMetadataFromIPFS } from "~~/utils/simpleNFT/ipfs";
 
 export async function POST(request: Request) {
-  const { ipfsHash } = await request.json();
-
-  const res = await getNFTMetadataFromIPFS(ipfsHash);
-
-  return Response.json(res);
+  try {
+    const { ipfsHash } = await request.json();
+    const res = await getNFTMetadataFromIPFS(ipfsHash);
+    return Response.json(res);
+  } catch (error) {
+    console.log("Error getting metadata from ipfs", error);
+    return Response.json({ error: "Error getting metadata from ipfs" });
+  }
 }


### PR DESCRIPTION
### Description:

I am sure but for some reason, certain people are facing this issue, when they click "Mint NFT" btn  : 
<details>
<summary>Error Image from TG chat</summary>

![IMG_7449](https://github.com/scaffold-eth/se-2-challenges/assets/80153681/fcf601d4-204f-4ba8-a3a9-d190d7f50d4f)

</details>

This doesn't happen to me and everything works fine for me, but a couple of people in the challenge 0 TG group faced this [1](https://t.me/c/1716981265/4190), [2](https://t.me/c/1716981265/4145)

Its mainly caused due infura and ipfs cilent not working properly for certain region / using VPN kind of related discussion on [infura](https://community.infura.io/t/ipfs-add-not-working/1554/4)

Neverthe less this PR wraps the api in try catch, so that atleast we are able to see cards on frontend ( although without NFT image) but people can move forward and submit the challenge it does not block them