### PR TITLE
Remove variable redeclarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ The basic overview for `ethToToken()` is we're going to define our variables to 
         require(msg.value > 0, "cannot swap 0 ETH");
         uint256 ethReserve = address(this).balance - msg.value;
         uint256 token_reserve = token.balanceOf(address(this));
-        uint256 tokenOutput = price(msg.value, ethReserve, token_reserve);
+        tokenOutput = price(msg.value, ethReserve, token_reserve);
 
         require(token.transfer(msg.sender, tokenOutput), "ethToToken(): reverted swap.");
         emit EthToTokenSwap(msg.sender, tokenOutput, msg.value);
@@ -430,7 +430,7 @@ The basic overview for `ethToToken()` is we're going to define our variables to 
     function tokenToEth(uint256 tokenInput) public returns (uint256 ethOutput) {
         require(tokenInput > 0, "cannot swap 0 tokens");
         uint256 token_reserve = token.balanceOf(address(this));
-        uint256 ethOutput = price(tokenInput, token_reserve, address(this).balance);
+        ethOutput = price(tokenInput, token_reserve, address(this).balance);
         require(token.transferFrom(msg.sender, address(this), tokenInput), "tokenToEth(): reverted swap.");
         (bool sent, ) = msg.sender.call{ value: ethOutput }("");
         require(sent, "tokenToEth: revert in transferring eth to you!");


### PR DESCRIPTION
Within the documentation in README.md, there were 2 instances of variable redeclarations. These redeclarations simply cause a warning and will still allow the code to compile.

```
function ethToToken() public payable returns (uint256 tokenOutput) {
    require(msg.value > 0, "cannot swap 0 ETH");
    uint256 ethReserve = address(this).balance - msg.value;
    uint256 token_reserve = token.balanceOf(address(this));
    uint256 tokenOutput = price(msg.value, ethReserve, token_reserve); // tokenOutput redeclared

    require(token.transfer(msg.sender, tokenOutput), "ethToToken(): reverted swap.");
    emit EthToTokenSwap(msg.sender, tokenOutput, msg.value);
    return tokenOutput;
 }
 ...
function tokenToEth(uint256 tokenInput) public returns (uint256 ethOutput) {
    require(tokenInput > 0, "cannot swap 0 tokens");
    uint256 token_reserve = token.balanceOf(address(this));
    uint256 ethOutput = price(tokenInput, token_reserve, address(this).balance); // ethOutput redeclared
    require(token.transferFrom(msg.sender, address(this), tokenInput), "tokenToEth(): reverted swap.");
    (bool sent, ) = msg.sender.call{ value: ethOutput }("");
    require(sent, "tokenToEth: revert in transferring eth to you!");
    emit TokenToEthSwap(msg.sender, tokenInput, ethOutput);
    return ethOutput;
}
```
The following 2 lines should have their type annotation removed to avoid warnings:
- `uint256 tokenOutput = price(msg.value, ethReserve, token_reserve);` -> `tokenOutput = price(msg.value, ethReserve, token_reserve);`
- `uint256 ethOutput = price(tokenInput, token_reserve, address(this).balance);` -> `ethOutput = price(tokenInput, token_reserve, address(this).balance);`

VSCode provider the following error: `This declaration shadows an existing declaration`
![Screenshot 2024-03-05 at 11 01 50 PM](https://github.com/scaffold-eth/se-2-challenges/assets/86010458/4386344f-0494-4849-9c0c-8252fdc40d81)

When deploying, the code successfully compiles but with the following warning:
```
Warning: This declaration shadows an existing declaration.
   --> contracts/DEX.sol:123:5:
    |
123 |     uint256 tokenOutput = price(msg.value, ethReserve, tokenReserve);
    |     ^^^^^^^^^^^^^^^^^^^
Note: The shadowed declaration is here:
   --> contracts/DEX.sol:119:48:
    |
119 | 	function ethToToken() public payable returns (uint256 tokenOutput) {
    | 	                                              ^^^^^^^^^^^^^^^^^^^
    ```
    
    Removing the above suggested type annotations will remove this warning.