### PR TITLE
add vercel.json with mention installCommand

### DIFF
--- a/packages/nextjs/vercel.json
+++ b/packages/nextjs/vercel.json
@@ -1,0 +1,3 @@
+{
+  "installCommand": "yarn install"
+}


### PR DESCRIPTION
### Description : 

Vercel now uses npm install by default and we get this : 

![image](https://github.com/scaffold-eth/se-2-challenges/assets/80153681/e4cadaff-048d-4a86-8e11-a15ad901b10e)
