### PR TITLE
Challenge 3 (Dice Game): Fix address-related errors/warnings

### DIFF
--- a/packages/nextjs/app/dice/_components/WinnerEvents.tsx
+++ b/packages/nextjs/app/dice/_components/WinnerEvents.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { Address as AddressType, Amount } from "./Amount";
-import { formatEther } from "viem";
+import { Amount } from "./Amount";
+import { Address as AddressType, formatEther } from "viem";
 import { Address } from "~~/components/scaffold-eth";
 
 export type Winner = {

--- a/packages/nextjs/app/dice/_components/WinnerEvents.tsx
+++ b/packages/nextjs/app/dice/_components/WinnerEvents.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
-import { Amount } from "./Amount";
+import { Address as AddressType, Amount } from "./Amount";
 import { formatEther } from "viem";
 import { Address } from "~~/components/scaffold-eth";
 
 export type Winner = {
-  address: string;
+  address: AddressType;
   amount: bigint;
 };
 

--- a/packages/nextjs/app/dice/page.tsx
+++ b/packages/nextjs/app/dice/page.tsx
@@ -49,7 +49,7 @@ const DiceGame: NextPage = () => {
       setRolls(
         (
           rollsHistoryData?.map(({ args }) => ({
-            address: args.player as string,
+            address: args.player!,
             amount: Number(args.amount),
             roll: (args.roll as bigint).toString(16).toUpperCase(),
           })) || []

--- a/packages/nextjs/app/dice/page.tsx
+++ b/packages/nextjs/app/dice/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import type { NextPage } from "next";
-import { formatEther, parseEther } from "viem";
+import { Address as AddressType, formatEther, parseEther } from "viem";
 import { Amount, Roll, RollEvents, Winner, WinnerEvents } from "~~/app/dice/_components";
 import { Address } from "~~/components/scaffold-eth";
 import {
@@ -49,7 +49,7 @@ const DiceGame: NextPage = () => {
       setRolls(
         (
           rollsHistoryData?.map(({ args }) => ({
-            address: args.player,
+            address: args.player as AddressType,
             amount: Number(args.amount),
             roll: (args.roll as bigint).toString(16).toUpperCase(),
           })) || []
@@ -76,7 +76,7 @@ const DiceGame: NextPage = () => {
       setWinners(
         (
           winnerHistoryData?.map(({ args }) => ({
-            address: args.winner,
+            address: args.winner as AddressType,
             amount: args.amount as bigint,
           })) || []
         ).slice(0, MAX_TABLE_ROWS),

--- a/packages/nextjs/app/dice/page.tsx
+++ b/packages/nextjs/app/dice/page.tsx
@@ -49,7 +49,7 @@ const DiceGame: NextPage = () => {
       setRolls(
         (
           rollsHistoryData?.map(({ args }) => ({
-            address: args.player!,
+            address: args.player,
             amount: Number(args.amount),
             roll: (args.roll as bigint).toString(16).toUpperCase(),
           })) || []
@@ -76,7 +76,7 @@ const DiceGame: NextPage = () => {
       setWinners(
         (
           winnerHistoryData?.map(({ args }) => ({
-            address: args.winner!,
+            address: args.winner,
             amount: args.amount as bigint,
           })) || []
         ).slice(0, MAX_TABLE_ROWS),

--- a/packages/nextjs/app/dice/page.tsx
+++ b/packages/nextjs/app/dice/page.tsx
@@ -76,7 +76,7 @@ const DiceGame: NextPage = () => {
       setWinners(
         (
           winnerHistoryData?.map(({ args }) => ({
-            address: args.winner as string,
+            address: args.winner!,
             amount: args.amount as bigint,
           })) || []
         ).slice(0, MAX_TABLE_ROWS),


### PR DESCRIPTION
- **Mark `args.player` as `viem/Address`** - fixes this error:
![image](https://github.com/user-attachments/assets/cb7d2eab-2c95-44fc-a052-23d4ecf23725)

- **Convert `Winner.address` type from `string` to `viem/Address`** - more accurate
- **Mark `args.winner` as `viem/Address`** - similar to first point


