### PR TITLE
Add Troubleshooting Tip for yarn account Showing 0 Balance in challenge-0-simple-nft

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ yarn start
 
 > 🌉 If you need to bridge funds from Sepolia to OP Sepolia, you can use the [Superchain Bridges](https://app.optimism.io/bridge/deposit). This allows you to transfer ETH and other supported tokens between the two networks.
 
+> Note: If your balance is 0, even when you have Sepolia ETH in it, configure the Alchemy RPC URL by adding your own custom URL (e.g., using ALCHEMY_API_KEY) to the .env file. Ensure the .env includes the required keys: DEPLOYER_PRIVATE_KEY=, ALCHEMY_API_KEY=, and ETHERSCAN_OPTIMISTIC_API_KEY=. This configuration is crucial for accurate balance readings.
+
 > ⚔️ Side Quest: Keep a 🧑‍🎤 [punkwallet.io](https://punkwallet.io) on your phone's home screen and keep it loaded with testnet eth. 🧙‍♂️ You'll look like a wizard when you can fund your deployer address from your phone in seconds.
 
 🚀 Deploy your NFT smart contract with `yarn deploy`.


### PR DESCRIPTION
This PR adds a troubleshooting note to the documentation for challenge-0-simple-nft. It addresses the issue of yarn account returning a balance of 0 even when the wallet has Sepolia ETH. The fix involves correctly configuring the RPC provider URL by replacing it with a custom Alchemy API URL and ensuring the .env file contains the necessary keys (ALCHEMY_API_KEY and DEPLOYER_PRIVATE_KEY).