### PR TITLE
Challenge 3: fix infinite useEffect loop

### DIFF
--- a/packages/nextjs/app/dice/page.tsx
+++ b/packages/nextjs/app/dice/page.tsx
@@ -47,13 +47,11 @@ const DiceGame: NextPage = () => {
       setIsRolling(false);
 
       setRolls(
-        (
-          rollsHistoryData?.map(({ args }) => ({
-            address: args.player as AddressType,
-            amount: Number(args.amount),
-            roll: (args.roll as bigint).toString(16).toUpperCase(),
-          })) || []
-        ).slice(0, MAX_TABLE_ROWS),
+        rollsHistoryData?.map(({ args }) => ({
+          address: args.player as AddressType,
+          amount: Number(args.amount),
+          roll: (args.roll as bigint).toString(16).toUpperCase(),
+        })) || [],
       );
     }
   }, [rolls, rollsHistoryData, rollsHistoryLoading]);
@@ -74,12 +72,10 @@ const DiceGame: NextPage = () => {
       setIsRolling(false);
 
       setWinners(
-        (
-          winnerHistoryData?.map(({ args }) => ({
-            address: args.winner as AddressType,
-            amount: args.amount as bigint,
-          })) || []
-        ).slice(0, MAX_TABLE_ROWS),
+        winnerHistoryData?.map(({ args }) => ({
+          address: args.winner as AddressType,
+          amount: args.amount as bigint,
+        })) || [],
       );
     }
   }, [winnerHistoryData, winnerHistoryLoading, winners.length]);
@@ -106,7 +102,7 @@ const DiceGame: NextPage = () => {
     <div className="py-10 px-10">
       <div className="grid grid-cols-3 max-lg:grid-cols-1">
         <div className="max-lg:row-start-2">
-          <RollEvents rolls={rolls} />
+          <RollEvents rolls={rolls.slice(0, MAX_TABLE_ROWS)} />
         </div>
 
         <div className="flex flex-col items-center pt-4 max-lg:row-start-1">
@@ -178,7 +174,7 @@ const DiceGame: NextPage = () => {
         </div>
 
         <div className="max-lg:row-start-3">
-          <WinnerEvents winners={winners} />
+          <WinnerEvents winners={winners.slice(0, MAX_TABLE_ROWS)} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
At some point we changed logic a bit, and
1. Maximum `rolls` and `winners` lengths could be from 0 to 10 because all the data was sliced before updating the state. Reason for this is that we show just last 10 rolls/winners
2. At our `useEffect`s we have a condition like `(rollsHistoryData?.length as number) > rolls.length)` so when `rollsHistoryData.length` becomes more than 10, `rolls.length` is not - it's still 10, and it means that mentioned condition is always `true`. So we have `setRolls(...)` inside that `useEffect` -> it changes `rolls` -> it executes that `useEffect` again etc -> infinite loop. Same for winners

This PR fixes it. Please check and after merging this I'll add changes to extension

Fixes #242 