### PR TITLE
Fixed typos in smart contracts

### DIFF
--- a/packages/hardhat/contracts/ExampleExternalContract.sol
+++ b/packages/hardhat/contracts/ExampleExternalContract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.4;  //Do not change the solidity version as it negativly impacts submission grading
+pragma solidity 0.8.4;  //Do not change the solidity version as it negatively impacts submission grading
 
 contract ExampleExternalContract {
 

--- a/packages/hardhat/contracts/Staker.sol
+++ b/packages/hardhat/contracts/Staker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.4;  //Do not change the solidity version as it negativly impacts submission grading
+pragma solidity 0.8.4;  //Do not change the solidity version as it negatively impacts submission grading
 
 import "hardhat/console.sol";
 import "./ExampleExternalContract.sol";


### PR DESCRIPTION
Fixed typos in `packages/hardhat/contracts`.