### PR TITLE
Fixed typos in smart contracts

### DIFF
--- a/packages/hardhat/contracts/Vendor.sol
+++ b/packages/hardhat/contracts/Vendor.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.4; //Do not change the solidity version as it negativly impacts submission grading
+pragma solidity 0.8.4; //Do not change the solidity version as it negatively impacts submission grading
 // SPDX-License-Identifier: MIT
 
 // import "@openzeppelin/contracts/access/Ownable.sol";

--- a/packages/hardhat/contracts/YourToken.sol
+++ b/packages/hardhat/contracts/YourToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.4; //Do not change the solidity version as it negativly impacts submission grading
+pragma solidity 0.8.4; //Do not change the solidity version as it negatively impacts submission grading
 // SPDX-License-Identifier: MIT
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";


### PR DESCRIPTION
Fixed typos in `packages/hardhat/contracts`.