### PR TITLE
Fixed typos in smart contracts

### DIFF
--- a/packages/hardhat/contracts/DiceGame.sol
+++ b/packages/hardhat/contracts/DiceGame.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.8.0 <0.9.0; //Do not change the solidity version as it negativly impacts submission grading
+pragma solidity >=0.8.0 <0.9.0; //Do not change the solidity version as it negatively impacts submission grading
 //SPDX-License-Identifier: MIT
 
 import "hardhat/console.sol";

--- a/packages/hardhat/contracts/RiggedRoll.sol
+++ b/packages/hardhat/contracts/RiggedRoll.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.8.0 <0.9.0;  //Do not change the solidity version as it negativly impacts submission grading
+pragma solidity >=0.8.0 <0.9.0;  //Do not change the solidity version as it negatively impacts submission grading
 //SPDX-License-Identifier: MIT
 
 import "hardhat/console.sol";


### PR DESCRIPTION
Fixed typos in `packages/hardhat/contracts`.