### PR TITLE
only set contract state when on hardhat chain

### DIFF
--- a/extension/packages/hardhat/deploy/00_deploy_contracts.ts
+++ b/extension/packages/hardhat/deploy/00_deploy_contracts.ts
@@ -55,22 +55,25 @@ const deployContracts: DeployFunction = async function (hre: HardhatRuntimeEnvir
     autoMine: true,
   });
 
-  // Give ETH and CORN to the move price contract
-  await hre.ethers.provider.send("hardhat_setBalance", [
-    movePrice.address,
-    `0x${hre.ethers.parseEther("10000000000000000000000").toString(16)}`,
-  ]);
-  await cornToken.mintTo(movePrice.address, hre.ethers.parseEther("10000000000000000000000"));
-  // Give CORN and ETH to the deployer
-  await cornToken.mintTo(deployer, hre.ethers.parseEther("1000000000000"));
-  await hre.ethers.provider.send("hardhat_setBalance", [
-    deployer,
-    `0x${hre.ethers.parseEther("100000000000").toString(16)}`,
-  ]);
+  // Only set up contract state on local network
+  if (hre.network.name == "localhost") {
+    // Give ETH and CORN to the move price contract
+    await hre.ethers.provider.send("hardhat_setBalance", [
+      movePrice.address,
+      `0x${hre.ethers.parseEther("10000000000000000000000").toString(16)}`,
+    ]);
+    await cornToken.mintTo(movePrice.address, hre.ethers.parseEther("10000000000000000000000"));
+    // Give CORN and ETH to the deployer
+    await cornToken.mintTo(deployer, hre.ethers.parseEther("1000000000000"));
+    await hre.ethers.provider.send("hardhat_setBalance", [
+      deployer,
+      `0x${hre.ethers.parseEther("100000000000").toString(16)}`,
+    ]);
 
-  await cornToken.transferOwnership(lending.address);
-  await cornToken.approve(cornDEX.target, hre.ethers.parseEther("1000000000"));
-  await cornDEX.init(hre.ethers.parseEther("1000000000"), { value: hre.ethers.parseEther("1000000") });
+    await cornToken.transferOwnership(lending.address);
+    await cornToken.approve(cornDEX.target, hre.ethers.parseEther("1000000000"));
+    await cornDEX.init(hre.ethers.parseEther("1000000000"), { value: hre.ethers.parseEther("1000000") });
+  }
 };
 
 export default deployContracts;


### PR DESCRIPTION
This just adds a check to see if the deployment is local so that we can avoid running the `hardhat_setBalance` methods when deploying to a real network. Ran into this yesterday while testing. I am inclined just to merge it since it is simple but I will let you guys check my logic as well.

Without this it still deploys fine but it gives a nasty error when it tries to use the `hardhat_setBalance` method on a real RPC.