### PR TITLE
Filters liquidators to include only those who have enough corn balance

### DIFF
--- a/extension/packages/hardhat/scripts/marketSimulator.ts
+++ b/extension/packages/hardhat/scripts/marketSimulator.ts
@@ -199,7 +199,6 @@ async function checkAndPerformLiquidations(lending: Lending, corn: Corn, account
     const liquidatorsWithBalance = await Promise.all(
       liquidators.map(async account => {
         const cornBalance = await corn.balanceOf(account.wallet.address);
-        //console.log(`Account ${account.wallet.address} has ${ethers.formatEther(cornBalance)} CORN. required: ${ethers.formatEther(amountBorrowed)}`);
         return { account, hasEnough: cornBalance >= amountBorrowed };
       })
     );


### PR DESCRIPTION
When running simulation experienced many liquidation errors. The reason is that everyone is included in the eligibleLiquidators list without checking CORN balance required for liquidation.

Added additional check for eligibleLiquidators to include only ones who have enough CORN to liquidate.