### PR TITLE
Fix ocl main page build

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Deploy your contracts to a testnet then build and upload your app to a public we
 📥 Then download the challenge to your computer and install dependencies by running:
 
 ```sh
-npx create-eth@0.2.3 -e challenge-over-collateralized-lending challenge-over-collateralized-lending
+npx create-eth@0.2.4 -e challenge-over-collateralized-lending challenge-over-collateralized-lending
 cd challenge-over-collateralized-lending
 ```
 

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -44,7 +44,7 @@ Deploy your contracts to a testnet then build and upload your app to a public we
 📥 Then download the challenge to your computer and install dependencies by running:
 
 \`\`\`sh
-npx create-eth@0.2.3 -e challenge-over-collateralized-lending challenge-over-collateralized-lending
+npx create-eth@0.2.4 -e challenge-over-collateralized-lending challenge-over-collateralized-lending
 cd challenge-over-collateralized-lending
 \`\`\`
 

--- a/extension/packages/nextjs/app/page.tsx.args.mjs
+++ b/extension/packages/nextjs/app/page.tsx.args.mjs
@@ -16,10 +16,10 @@ export const description = `
         />
         <div className="max-w-3xl">
           <p className="text-center text-lg mt-8">
-            💳 Build your own lending and borrowing platform. Let's write a contract that takes collateral and lets you borrow other assets against the value of the collateral. What happens when the collateral changes in value? We will be able to borrow more if it is higher or if it is lower we will also build a system for liquidating the debt position.
+            💳 Build your own lending and borrowing platform. Let&apos;s write a contract that takes collateral and lets you borrow other assets against the value of the collateral. What happens when the collateral changes in value? We will be able to borrow more if it is higher or if it is lower we will also build a system for liquidating the debt position.
           </p>
           <p className="text-center text-lg">
-            🌟 The final deliverable is an app that allows anyone to take out a loan in CORN while making sure it is always backed by it's value in ETH.
+            🌟 The final deliverable is an app that allows anyone to take out a loan in CORN while making sure it is always backed by it&apos;s value in ETH.
             Deploy your contracts to a testnet then build and upload your app to a public web server. Submit the url on{" "}
             <a href="https://speedrunethereum.com/" target="_blank" rel="noreferrer" className="underline">
               SpeedRunEthereum.com


### PR DESCRIPTION
To test 

```
npx create-eth@0.2.3 -e https://github.com/scaffold-eth/se-2-challenges/tree/fix-main-page challenge-over-collateralized-lending
```

Add all the contracts and deployment code (copy-paste from solutions on the challenge page)

Run

```
yarn next:build
```

You shouldn't see main page build error. The only build error should be this
```
 ✓ Compiled successfully
   Linting and checking validity of types  ...Failed to compile.

./services/web3/wagmiConnectors.tsx:35:7
Type error: Type '((({ projectId, walletConnectParameters, }: DefaultWalletOptions) => Wallet) | (({ projectId, options, }: WalletConnectWalletOptions) => Wallet) | CoinbaseWallet | RainbowkitBurnerWallet)[]' is not assignable to type 'CreateWalletFn[]'.
...
```

which will be fixed after updating `burner-connector` version to 0.0.16 on create-eth. You can test in the instance so update `burner-connector` version -> `yarn next:build` and no errors, only indexedDb warning



