### PR TITLE
remove "in" due to parser/linter issues in Vercel deployment

### DIFF
--- a/extension/packages/nextjs/app/dashboard/_components/CollateralGraph.tsx
+++ b/extension/packages/nextjs/app/dashboard/_components/CollateralGraph.tsx
@@ -102,7 +102,7 @@ const CollateralGraph = () => {
     const collateralAdded: bigint = event?.eventName === "CollateralAdded" ? event?.args.amount || 0n : 0n;
     const collateralWithdrawn: bigint = event?.eventName === "CollateralWithdrawn" ? event?.args.amount || 0n : 0n;
     const price: bigint =
-      "price" in event?.args ? event?.args.price : getPriceFromEvent(event?.blockNumber, priceEvents);
+      event?.args && event?.args.price ? event?.args.price : getPriceFromEvent(event?.blockNumber, priceEvents);
     const debtAdded: bigint = event?.eventName === "AssetBorrowed" ? event?.args.amount || 0n : 0n;
     const debtRepaid: bigint = event?.eventName === "AssetRepaid" ? event?.args.amount || 0n : 0n;
     const amountForLiquidator: bigint = event?.eventName === "Liquidation" ? event?.args.amountForLiquidator || 0n : 0n;

--- a/extension/packages/nextjs/app/dashboard/_components/CollateralGraph.tsx
+++ b/extension/packages/nextjs/app/dashboard/_components/CollateralGraph.tsx
@@ -101,8 +101,7 @@ const CollateralGraph = () => {
 
     const collateralAdded: bigint = event?.eventName === "CollateralAdded" ? event?.args.amount || 0n : 0n;
     const collateralWithdrawn: bigint = event?.eventName === "CollateralWithdrawn" ? event?.args.amount || 0n : 0n;
-    const price: bigint =
-      event?.args && event?.args.price ? event?.args.price : getPriceFromEvent(event?.blockNumber, priceEvents);
+    const price: bigint = event?.args?.price ?? getPriceFromEvent(event?.blockNumber, priceEvents);
     const debtAdded: bigint = event?.eventName === "AssetBorrowed" ? event?.args.amount || 0n : 0n;
     const debtRepaid: bigint = event?.eventName === "AssetRepaid" ? event?.args.amount || 0n : 0n;
     const amountForLiquidator: bigint = event?.eventName === "Liquidation" ? event?.args.amountForLiquidator || 0n : 0n;


### PR DESCRIPTION
A user in telegram reported this issue where deploying to Vercel was not happening due to this error:
https://t.me/c/2648952355/20

This change should resolve the linter error and allow deployment to Vercel.

I tested it and was able to successfully deploy to Vercel. Also everything worked as expected with the collateral graph.