### PR TITLE
 Fix tooltip text wrapping for long contract paths

### DIFF
--- a/extension/packages/nextjs/styles/globals.css.args.mjs
+++ b/extension/packages/nextjs/styles/globals.css.args.mjs
@@ -57,4 +57,11 @@ export const postContent = `
 
 @theme inline {
   --font-space-grotesk: var(--font-space-grotesk);
+}
+
+/* Fix for Debug Contracts tooltips - allows text wrapping for long paths */
+.tooltip.tooltip-accent::before {
+  white-space: normal;
+  max-width: 320px;
+  word-wrap: break-word;
 }`;


### PR DESCRIPTION
  ## Summary
  Fixes tooltip background cutoff issue for long inheritance
  paths in Debug Contracts page.

  ## Problem
  Tooltips showing inheritance information (e.g., "Inherited
  from: @openzeppelin/contracts/token/ERC721/extensions/ERC721UR
  IStorage.sol") had their backgrounds cut off when text was too
   long.

  ## Solution
  - Add CSS styles to allow text wrapping in accent tooltips
  - Set max-width: 320px to prevent overly wide tooltips
  - Enable word-wrap: break-word for long contract paths
  - Target only `.tooltip.tooltip-accent` to avoid affecting
  other tooltips

  ## Files Changed
  - `extension/packages/nextjs/styles/globals.css.args.mjs`

  ## Testing
  Tested on Debug Contracts page with inherited functions
  showing long contract paths.
![bug](https://github.com/user-attachments/assets/6103c764-2b12-4986-9a50-b3143cde1976)
![fix](https://github.com/user-attachments/assets/ab842d35-65d6-401d-9d58-39449bb8bba3)
