### PR TITLE
Grader update challenge gh action

### DIFF
--- a/.github/workflows/grader-update-challenge.yaml
+++ b/.github/workflows/grader-update-challenge.yaml
@@ -50,12 +50,12 @@ jobs:
           CHALLENGE_ID="${{ steps.extract_challenge.outputs.challenge_id }}"
 
           echo "Updating test files on autograding server for challenge: $CHALLENGE_ID"
-          echo "Autograding server URL: ${{ secrets.AUTOGRADING_SERVER }}/install"
+          echo "Autograding server URL: ${{ secrets.AUTOGRADER_URL }}/install"
 
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
-            "${{ secrets.AUTOGRADING_SERVER }}/install" \
+            "${{ secrets.AUTOGRADER_URL }}/install" \
             -H "Content-Type: application/json" \
-            -H "x-api-key: ${{ secrets.API_KEY }}" \
+            -H "x-api-key: ${{ secrets.AUTOGRADER_API_KEY }}" \
             -d "{\"challengeId\": \"$CHALLENGE_ID\"}")
 
           HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
@@ -79,7 +79,7 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Challenge ID:** \`${{ steps.extract_challenge.outputs.challenge_id }}\`" >> $GITHUB_STEP_SUMMARY
             echo "**Branch:** \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
-            echo "**Autograding Server:** \`${{ secrets.AUTOGRADING_SERVER }}/install\`" >> $GITHUB_STEP_SUMMARY
+            echo "**Autograding Server:** \`${{ secrets.AUTOGRADER_URL }}/install\`" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             if [ "${{ job.status }}" = "success" ]; then
               echo "✅ **Status:** Successfully updated test files on autograding server" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/grader-update-challenge.yaml
+++ b/.github/workflows/grader-update-challenge.yaml
@@ -1,0 +1,93 @@
+name: Grader update challenge
+
+on:
+  push:
+    paths:
+      - "extension/packages/hardhat/test/**"
+    branches:
+      - "challenge-*"
+  pull_request:
+    paths:
+      - "extension/packages/hardhat/test/**"
+    branches:
+      - "challenge-*"
+    types: [closed]
+
+jobs:
+  notify-autograder:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract challenge ID from branch
+        id: extract_challenge
+        run: |
+          # Get the branch name
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BRANCH_NAME="${{ github.event.pull_request.base.ref }}"
+          else
+            BRANCH_NAME="${{ github.ref_name }}"
+          fi
+
+          echo "Branch name: $BRANCH_NAME"
+
+          # Use the full branch name as challenge ID (e.g., challenge-simple-nft-example)
+          if [[ $BRANCH_NAME =~ ^challenge-.+$ ]]; then
+            CHALLENGE_ID="$BRANCH_NAME"
+            echo "challenge_id=$CHALLENGE_ID" >> $GITHUB_OUTPUT
+            echo "Challenge ID: $CHALLENGE_ID"
+          else
+            echo "Branch name does not match challenge pattern: $BRANCH_NAME"
+            exit 1
+          fi
+
+      - name: Update test files on autograding server
+        if: steps.extract_challenge.outputs.challenge_id != ''
+        run: |
+          CHALLENGE_ID="${{ steps.extract_challenge.outputs.challenge_id }}"
+
+          echo "Updating test files on autograding server for challenge: $CHALLENGE_ID"
+          echo "Autograding server URL: ${{ secrets.AUTOGRADING_SERVER }}/install"
+
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+            "${{ secrets.AUTOGRADING_SERVER }}/install" \
+            -H "Content-Type: application/json" \
+            -H "x-api-key: ${{ secrets.API_KEY }}" \
+            -d "{\"challengeId\": \"$CHALLENGE_ID\"}")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+          RESPONSE_BODY=$(echo "$RESPONSE" | head -n -1)
+
+          echo "HTTP Status Code: $HTTP_CODE"
+          echo "Response: $RESPONSE_BODY"
+
+          if [ "$HTTP_CODE" -eq 200 ]; then
+            echo "✅ Successfully updated test files on autograding server for challenge $CHALLENGE_ID"
+          else
+            echo "❌ Failed to update test files on autograding server for challenge $CHALLENGE_ID (HTTP $HTTP_CODE)"
+            exit 1
+          fi
+
+      - name: Add summary
+        if: always()
+        run: |
+          if [ "${{ steps.extract_challenge.outputs.challenge_id }}" != "" ]; then
+            echo "## 🧪 Test Files Update" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Challenge ID:** \`${{ steps.extract_challenge.outputs.challenge_id }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "**Branch:** \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "**Autograding Server:** \`${{ secrets.AUTOGRADING_SERVER }}/install\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            if [ "${{ job.status }}" = "success" ]; then
+              echo "✅ **Status:** Successfully updated test files on autograding server" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "❌ **Status:** Failed to update test files on autograding server" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "## 🧪 Test Files Update" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "❌ **Status:** Could not extract challenge ID from branch" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/grader-update-challenge.yaml
+++ b/.github/workflows/grader-update-challenge.yaml
@@ -6,12 +6,6 @@ on:
       - "extension/packages/hardhat/test/**"
     branches:
       - "challenge-*"
-  pull_request:
-    paths:
-      - "extension/packages/hardhat/test/**"
-    branches:
-      - "challenge-*"
-    types: [closed]
 
 jobs:
   notify-autograder:
@@ -19,9 +13,6 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Extract challenge ID from branch
         id: extract_challenge
         run: |


### PR DESCRIPTION
Github action which updates test file on grader when pushing to `challenge-*` branch or successfully merging PR to `challenge-*` branch

---

tested it locally with [act](https://nektosact.com/introduction.html)

Steps:
- install act. For me it was `brew install act` (macOS)
- run docker
- run grader locally. Remove/rename `challenge-simple-nft-example` test
- create new branch from some challenge of this repo (se-2-challenges), for example from `challenge-simple-nft-example`.
- add this action to that branch
- create `.env` file with two variables

```
AUTOGRADER_API_KEY =<api key> // add the same key to the local grader (in grader it named API_KEY)
AUTOGRADER_URL=http://host.docker.internal:54727
```
Run the full workflow

```
act push --secret-file .env --container-architecture linux/amd64 --pull=false
```

Expected Results
When successful, you should see:
✅ HTTP Status Code: 200
✅ Response: Successfully installed/updated challenge
✅ Test file downloaded from the challenge branch to your autograding server
✅ Job succeeded

and file test file in local grader should appear

---

Before merge we need to add `AUTOGRADER_API_KEY and AUTOGRADER_URL` values to repo secrets