### PR TITLE
Fix two spelling typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Before deploying, make one important change:
 
 Once that’s done, you’re ready to deploy! 🔗
 
-Run`yarn deploy` and check out the front-end
+Run `yarn deploy` and check out the front-end
 
 ### **🥅 Goals**
 
@@ -1795,7 +1795,7 @@ Configure your keys here:
 
 ### Deploying Your Smart Contracts
 
-🔐 You will need to generate a **deployer address** using `yarn generate`. his creates a mnemonic and saves it locally.
+🔐 You will need to generate a **deployer address** using `yarn generate`. This creates a mnemonic and saves it locally.
 
 👩‍🚀 Use `yarn account` to view your deployer account balances.
 

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -381,7 +381,7 @@ Before deploying, make one important change:
 
 Once that’s done, you’re ready to deploy! 🔗
 
-Run\`yarn deploy\` and check out the front-end
+Run \`yarn deploy\` and check out the front-end
 
 ### **🥅 Goals**
 
@@ -1800,7 +1800,7 @@ Configure your keys here:
 
 ### Deploying Your Smart Contracts
 
-🔐 You will need to generate a **deployer address** using \`yarn generate\`. his creates a mnemonic and saves it locally.
+🔐 You will need to generate a **deployer address** using \`yarn generate\`. This creates a mnemonic and saves it locally.
 
 👩‍🚀 Use \`yarn account\` to view your deployer account balances.
 


### PR DESCRIPTION
## Fix spelling typos in README

This PR fixes two spelling mistakes found in the ZK Voting challenge README:

### Changes

1. **Checkpoint 2, line 379**: Fixed missing space between "Run" and "yarn"
   - Before: `Runyarn deploy`
   - After: `Run yarn deploy`

2. **Checkpoint 11, line 1798**: Fixed missing capital "T" at the start of sentence
   - Before: `his creates a mnemonic`
   - After: `This creates a mnemonic`
