### PR TITLE
add predictionNotReported modifier hint to Checkpoint 5 solution code

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,10 @@ function report(Outcome _winningOutcome) external predictionNotReported {
     s_isReported = true;
     emit MarketReported(msg.sender, _winningOutcome, address(s_winningToken));
 }
+
+// 🔒 Don't forget to add the predictionNotReported modifier to your existing liquidity functions:
+function addLiquidity() external payable onlyOwner predictionNotReported { ... }
+function removeLiquidity(uint256 _ethToWithdraw) external onlyOwner predictionNotReported { ... }
 ```
 
 </details>
@@ -1156,7 +1160,7 @@ Now that you've built the pricing engine (`getBuyPriceInEth` / `getSellPriceInEt
 
 - `sellTokensForEth`
 
-## 🛒 Buying Tokens
+### 🛒 Buying Tokens
 
 Before a user can grab some "Yes" or "No" tokens, we need to run a few sanity checks:
 

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -772,6 +772,10 @@ function report(Outcome _winningOutcome) external predictionNotReported {
     s_isReported = true;
     emit MarketReported(msg.sender, _winningOutcome, address(s_winningToken));
 }
+
+// 🔒 Don't forget to add the predictionNotReported modifier to your existing liquidity functions:
+function addLiquidity() external payable onlyOwner predictionNotReported { ... }
+function removeLiquidity(uint256 _ethToWithdraw) external onlyOwner predictionNotReported { ... }
 \`\`\`
 
 </details>
@@ -1159,7 +1163,7 @@ Now that you've built the pricing engine (\`getBuyPriceInEth\` / \`getSellPriceI
 
 - \`sellTokensForEth\`
 
-## 🛒 Buying Tokens
+### 🛒 Buying Tokens
 
 Before a user can grab some "Yes" or "No" tokens, we need to run a few sanity checks:
 


### PR DESCRIPTION
Hi, just two quick fixs:

The solution code for Checkpoint 5 was missing guidance to add the predictionNotReported modifier to addLiquidity and removeLiquidity. Because of that, students missed this step and failed the corresponding tests.

There is also a formatting issue in one of the headers, which is now fixed.