### PR TITLE
Challenge zk voting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,16 @@ nargo --version
 
 Install with:
 
-```sh
-curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/next/barretenberg/bbup/install | bash
-bbup -v 0.82.2
+```bash
+# Mac (Apple Silicon):
+mkdir -p ~/.bb && curl -L https://github.com/AztecProtocol/aztec-packages/releases/download/v0.82.2/barretenberg-arm64-darwin.tar.gz | tar -xzC ~/.bb
+# Mac (Intel):
+# mkdir -p ~/.bb && curl -L https://github.com/AztecProtocol/aztec-packages/releases/download/v0.82.2/barretenberg-amd64-darwin.tar.gz | tar -xzC ~/.bb
+# Linux (x86_64):
+# mkdir -p ~/.bb && curl -L https://github.com/AztecProtocol/aztec-packages/releases/download/v0.82.2/barretenberg-amd64-linux.tar.gz | tar -xzC ~/.bb
+
+# Add to PATH (add this to your ~/.zshrc or ~/.bashrc to make it permanent)
+export PATH="$HOME/.bb:$PATH"
 bb --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ nargo --version
 
 Install with:
 
-```bash
+```sh
 # Mac (Apple Silicon):
 mkdir -p ~/.bb && curl -L https://github.com/AztecProtocol/aztec-packages/releases/download/v0.82.2/barretenberg-arm64-darwin.tar.gz | tar -xzC ~/.bb
 # Mac (Intel):

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -72,7 +72,7 @@ nargo --version
 
 Install with:
 
-\`\`\`javascript
+\`\`\`sh
 # Mac (Apple Silicon):
 mkdir -p ~/.bb && curl -L https://github.com/AztecProtocol/aztec-packages/releases/download/v0.82.2/barretenberg-arm64-darwin.tar.gz | tar -xzC ~/.bb
 # Mac (Intel):

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -73,8 +73,15 @@ nargo --version
 Install with:
 
 \`\`\`javascript
-curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/next/barretenberg/bbup/install | bash
-bbup -v 0.82.2
+# Mac (Apple Silicon):
+mkdir -p ~/.bb && curl -L https://github.com/AztecProtocol/aztec-packages/releases/download/v0.82.2/barretenberg-arm64-darwin.tar.gz | tar -xzC ~/.bb
+# Mac (Intel):
+# mkdir -p ~/.bb && curl -L https://github.com/AztecProtocol/aztec-packages/releases/download/v0.82.2/barretenberg-amd64-darwin.tar.gz | tar -xzC ~/.bb
+# Linux (x86_64):
+# mkdir -p ~/.bb && curl -L https://github.com/AztecProtocol/aztec-packages/releases/download/v0.82.2/barretenberg-amd64-linux.tar.gz | tar -xzC ~/.bb
+
+# Add to PATH (add this to your ~/.zshrc or ~/.bashrc to make it permanent)
+export PATH="$HOME/.bb:$PATH"
 bb --version
 \`\`\`
 


### PR DESCRIPTION
Hi,        

The `bbup` installer script was unreliable, so I replaced it with direct binary download instructions for each platform (Apple Silicon, Intel Mac, Linux) in both README.md and extension/README.md.args.mjs.
                                                                                                                        
Would be great if you could test whether the installation works for you.

At some point I should also update the challenge to the latest versions of Noir and bb.

Thanks and best
Philip