### PR TITLE
fix: dark theme colors leaking into /debug page

### DIFF
--- a/extension/packages/nextjs/styles/globals.css.args.mjs
+++ b/extension/packages/nextjs/styles/globals.css.args.mjs
@@ -57,4 +57,26 @@ export const postContent = `
 
 @theme inline {
   --font-space-grotesk: var(--font-space-grotesk);
+};
+
+/* Override Scaffold UI theme colors */
+html[data-theme] {
+  --color-sui-primary: var(--color-primary);
+  --color-sui-primary-content: var(--color-primary-content);
+  --color-sui-primary-subtle: var(--color-secondary);
+  --color-sui-primary-neutral: var(--color-base-200);
+  --color-sui-base-content: var(--color-base-content);
+  --color-sui-base-100: var(--color-base-100);
+  --color-sui-neutral: var(--color-neutral);
+  --color-sui-neutral-content: var(--color-neutral-content);
+  --color-sui-accent: var(--color-accent);
+
+  --color-sui-input-border: var(--color-secondary);
+  --color-sui-input-background: var(--color-base-200);
+  --color-sui-input-text: color-mix(in oklab, var(--color-sui-base-content) 70%, transparent);
+  --color-sui-input-border-error: var(--color-sui-error);
+  --color-sui-input-border-disabled: var(--color-sui-primary-subtle);
+
+  --color-sui-skeleton-base: var(--color-sui-primary-subtle);
+  --color-sui-skeleton-highlight: var(--color-sui-primary-neutral);
 }`;


### PR DESCRIPTION
The `:root` overrides for `--color-sui-*` variables in `globals.css` were losing the cascade on `/debug` because `@scaffold-ui/debug-contracts/styles.css` is imported from a route-level client component and loads *after* `globals.css`, re-declaring the same variables at `:root` with library defaults.

Fixes:
  - Bump override selector specificity from `:root` (0,1,0) to `html[data-theme]` (0,1,1) so app values win regardless of CSS import order.
  - Add missing `--color-sui-base-100`, `--color-sui-neutral`, `--color-sui-neutral-content` overrides (used by Contract UI cards).
  - Add explicit `--color-sui-input-border-error` and `--color-sui-input-border-disabled` mappings. 

TODO:
After this is merged backmerge to all the challenges
Tokenization challenge example: https://github.com/scaffold-eth/se-2-challenges/pull/452

Fixes #447 