### PR TITLE
feat: dex migration to hh v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 Then download the challenge to your computer and install dependencies by running:
 
 ```sh
-npx create-eth@2.0.18 -e challenge-dex challenge-dex
+npx create-eth@2.0.20 -e challenge-dex challenge-dex
 ```
 
 > When prompted, choose your preferred Solidity framework: **Hardhat** or **Foundry**.

--- a/extension/packages/hardhat/deploy/00_deploy_dex.ts
+++ b/extension/packages/hardhat/deploy/00_deploy_dex.ts
@@ -1,71 +1,43 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { DEX } from "../typechain-types/contracts/DEX";
-import { Balloons } from "../typechain-types/contracts/Balloons";
+import { artifacts, deployScript } from "../rocketh/deploy.js";
 
 /**
- * Deploys a contract named "YourContract" using the deployer account and
- * constructor arguments set to the deployer address
+ * Deploys "Balloons" and "DEX".
  *
- * @param hre HardhatRuntimeEnvironment object.
+ * On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+ *
+ * When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
+ * should have sufficient balance to pay for the gas fees for contract creation.
+ *
+ * You can generate a random account with `yarn generate` which will fill DEPLOYER_PRIVATE_KEY_ENCRYPTED
+ * in the .env file (used in hardhat.config.ts).
+ * Run `yarn account` to check the deployer balance on every network.
  */
-const deployYourContract: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  /*
-    On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+export default deployScript(
+  async ({ deploy, namedAccounts }) => {
+    const { deployer } = namedAccounts;
 
-    When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
-    should have sufficient balance to pay for the gas fees for contract creation.
+    const balloons = await deploy("Balloons", {
+      account: deployer,
+      artifact: artifacts.Balloons,
+      args: [],
+    });
 
-    You can generate a random account with `yarn generate` which will fill DEPLOYER_PRIVATE_KEY
-    with a random private key in the .env file (then used on hardhat.config.ts)
-    You can run the `yarn account` command to check your balance in every network.
-  */
-  const { deployer } = await hre.getNamedAccounts();
-  const { deploy } = hre.deployments;
+    await deploy("DEX", {
+      account: deployer,
+      artifact: artifacts.DEX,
+      args: [balloons.address],
+    });
 
-  await deploy("Balloons", {
-    from: deployer,
-    // Contract constructor arguments
-    //args: [deployer],
-    log: true,
-    // autoMine: can be passed to the deploy function to make the deployment process faster on local networks by
-    // automatically mining the contract deployment transaction. There is no effect on live networks.
-    autoMine: true,
-  });
-  // Get the deployed contract
-  // const yourContract = await hre.ethers.getContract("YourContract", deployer);
-  const balloons: Balloons = await hre.ethers.getContract("Balloons", deployer);
-  const balloonsAddress = await balloons.getAddress();
+    // // CHECKPOINT 2: Paste in your front-end address here to get 10 balloons on deploy:
+    // await execute(balloons, { functionName: "transfer", args: ["YOUR_FRONTEND_ADDRESS", parseEther("10")], account: deployer });
 
-  await deploy("DEX", {
-    from: deployer,
-    // Contract constructor arguments
-    args: [balloonsAddress],
-    log: true,
-    // autoMine: can be passed to the deploy function to make the deployment process faster on local networks by
-    // automatically mining the contract deployment transaction. There is no effect on live networks.
-    autoMine: true,
-  });
-
-  const dex = (await hre.ethers.getContract("DEX", deployer)) as DEX;
-
-  // // CHECKPOINT 2: Paste in your front-end address here to get 10 balloons on deploy:
-  // await balloons.transfer("YOUR_FRONTEND_ADDRESS", "" + 10 * 10 ** 18);
-
-  // // CHECKPOINT 3: Uncomment to init DEX on deploy:
-  // const dexAddress = await dex.getAddress();
-  // console.log("Approving DEX (" + dexAddress + ") to take Balloons from main account...");
-  // // If you are going to the testnet make sure your deployer account has enough ETH
-  // await balloons.approve(dexAddress, hre.ethers.parseEther("100"));
-  // console.log("INIT exchange...");
-  // await dex.init(hre.ethers.parseEther("5"), {
-  //   value: hre.ethers.parseEther("5"),
-  //   gasLimit: 200000,
-  // });
-};
-
-export default deployYourContract;
-
-// Tags are useful if you have multiple deploy files and only want to run one of them.
-// e.g. yarn deploy --tags YourContract
-deployYourContract.tags = ["Balloons", "DEX"];
+    // // CHECKPOINT 3: Uncomment to init DEX on deploy:
+    // console.log("Approving DEX (" + dex.address + ") to take Balloons from main account...");
+    // await execute(balloons, { functionName: "approve", args: [dex.address, parseEther("100")], account: deployer });
+    // console.log("INIT exchange...");
+    // await execute(dex, { functionName: "init", args: [parseEther("5")], value: parseEther("5"), account: deployer });
+  },
+  // Tags are useful if you have multiple deploy files and only want to run one of them.
+  // e.g. yarn deploy --tags DEX
+  { tags: ["Balloons", "DEX"] },
+);

--- a/extension/packages/hardhat/deploy/00_deploy_dex.ts
+++ b/extension/packages/hardhat/deploy/00_deploy_dex.ts
@@ -1,3 +1,4 @@
+import { parseEther } from "viem";
 import { artifacts, deployScript } from "../rocketh/deploy.js";
 
 /**
@@ -13,7 +14,7 @@ import { artifacts, deployScript } from "../rocketh/deploy.js";
  * Run `yarn account` to check the deployer balance on every network.
  */
 export default deployScript(
-  async ({ deploy, namedAccounts }) => {
+  async ({ deploy, execute, namedAccounts }) => {
     const { deployer } = namedAccounts;
 
     const balloons = await deploy("Balloons", {
@@ -22,14 +23,16 @@ export default deployScript(
       args: [],
     });
 
-    await deploy("DEX", {
+    const dex = await deploy("DEX", {
       account: deployer,
       artifact: artifacts.DEX,
       args: [balloons.address],
     });
 
-    // // CHECKPOINT 2: Paste in your front-end address here to get 10 balloons on deploy:
-    // await execute(balloons, { functionName: "transfer", args: ["YOUR_FRONTEND_ADDRESS", parseEther("10")], account: deployer });
+    // // CHECKPOINT 2: Replace with your front-end address to get 10 balloons on deploy.
+    // // Default is the Hardhat test account #1 — works out-of-the-box on local.
+    // const frontendAddress = "YOUR_FRONTEND_ADDRESS";
+    // await execute(balloons, { functionName: "transfer", args: [frontendAddress, parseEther("10")], account: deployer });
 
     // // CHECKPOINT 3: Uncomment to init DEX on deploy:
     // console.log("Approving DEX (" + dex.address + ") to take Balloons from main account...");

--- a/extension/packages/hardhat/test/DEX.ts
+++ b/extension/packages/hardhat/test/DEX.ts
@@ -8,12 +8,18 @@
 //   yarn test --grep "Checkpoint5"
 //
 
-import { ethers } from "hardhat";
+import { network } from "hardhat";
 import { expect } from "chai";
-import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
-import { Balloons, DEX } from "../typechain-types";
+import { anyValue } from "@nomicfoundation/hardhat-ethers-chai-matchers/withArgs";
+import type { Balloons, DEX } from "../types/ethers-contracts/index.js";
 
 describe("🚩 Challenge: ⚖️ 🪙 DEX", function () {
+  let ethers: Awaited<ReturnType<typeof network.create>>["ethers"];
+
+  before(async function () {
+    ({ ethers } = await network.create());
+  });
+
   const contractAddress = process.env.CONTRACT_ADDRESS;
   const getDexArtifact = () => {
     if (contractAddress) return `contracts/download-${contractAddress}.sol:DEX`;
@@ -24,11 +30,11 @@ describe("🚩 Challenge: ⚖️ 🪙 DEX", function () {
     const [deployer, user2, user3] = await ethers.getSigners();
 
     const BalloonsFactory = await ethers.getContractFactory("Balloons");
-    const balloons = (await BalloonsFactory.deploy()) as Balloons;
+    const balloons = (await BalloonsFactory.deploy()) as unknown as Balloons;
     await balloons.waitForDeployment();
 
     const DexFactory = await ethers.getContractFactory(getDexArtifact());
-    const dex = (await DexFactory.deploy(await balloons.getAddress())) as DEX;
+    const dex = (await DexFactory.deploy(await balloons.getAddress())) as unknown as DEX;
     await dex.waitForDeployment();
 
     return {

--- a/extension/packages/hardhat/test/DEX.ts
+++ b/extension/packages/hardhat/test/DEX.ts
@@ -68,8 +68,9 @@ describe("🚩 Challenge: ⚖️ 🪙 DEX", function () {
       expect(await dex.totalLiquidity()).to.equal(0);
 
       await balloons.approve(dexAddress, ethers.parseEther("100"));
-      await expect(dex.init(ethers.parseEther("5"), { value: ethers.parseEther("5"), gasLimit: 200000 })).to.not.be
-        .reverted;
+      await expect(dex.init(ethers.parseEther("5"), { value: ethers.parseEther("5"), gasLimit: 200000 })).to.not.revert(
+        ethers,
+      );
 
       expect(await dex.totalLiquidity()).to.equal(ethers.parseEther("5"));
     });
@@ -97,20 +98,20 @@ describe("🚩 Challenge: ⚖️ 🪙 DEX", function () {
     it("Checkpoint3: calculates price correctly (includes 0.3% fee)", async function () {
       const { dex } = await deployFixture();
 
-        let xInput = ethers.parseEther("1");
-        let xReserves = ethers.parseEther("5");
-        let yReserves = ethers.parseEther("5");
+      let xInput = ethers.parseEther("1");
+      let xReserves = ethers.parseEther("5");
+      let yReserves = ethers.parseEther("5");
       let yOutput = await dex.price(xInput, xReserves, yReserves);
-        expect(
-          yOutput.toString(),
+      expect(
+        yOutput.toString(),
         "Check your price function's calculations. Don't forget the 0.3% fee (997/1000).",
-        ).to.equal("831248957812239453");
+      ).to.equal("831248957812239453");
 
-        xInput = ethers.parseEther("1");
-        xReserves = ethers.parseEther("10");
-        yReserves = ethers.parseEther("15");
+      xInput = ethers.parseEther("1");
+      xReserves = ethers.parseEther("10");
+      yReserves = ethers.parseEther("15");
       yOutput = await dex.price(xInput, xReserves, yReserves);
-        expect(yOutput.toString()).to.equal("1359916340820223697");
+      expect(yOutput.toString()).to.equal("1359916340820223697");
     });
   });
 
@@ -210,4 +211,3 @@ describe("🚩 Challenge: ⚖️ 🪙 DEX", function () {
     });
   });
 });
-

--- a/extension/packages/nextjs/next.config.ts.args.mjs
+++ b/extension/packages/nextjs/next.config.ts.args.mjs
@@ -2,7 +2,4 @@ export const configOverrides = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
 };


### PR DESCRIPTION
## Summary
- Migrate Hardhat deploy from `hardhat-deploy` (`DeployFunction` / `HardhatRuntimeEnvironment`) to `rocketh`'s `deployScript`.
- Migrate Hardhat tests from top-level `ethers` import to `network.create()` in `before` hook; switch typechain imports from `../typechain-types` to `../types/ethers-contracts/index.js`.
- Remove `eslint.ignoreDuringBuilds` from `next.config.ts.args.mjs` for Next.js 16.
- Replace `@nomicfoundation/hardhat-chai-matchers/withArgs` with `@nomicfoundation/hardhat-ethers-chai-matchers/withArgs`.

## Test plan
- [ ] `yarn install` succeeds in a generated project with this extension
- [ ] `yarn chain` + `yarn deploy` deploys Balloons + DEX
- [ ] `yarn hardhat:test` passes