### PR TITLE
feat: zk-voting migration to hh v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If you are using vscode you may want to install the [Noir Language Support](http
 Then download the challenge to your computer and install dependencies by running:
 
 ```sh
-npx create-eth@2.0.18 -e scaffold-eth/se-2-challenges:challenge-zk-voting challenge-zk-voting
+npx create-eth@2.0.20 -e scaffold-eth/se-2-challenges:challenge-zk-voting challenge-zk-voting
 cd challenge-zk-voting
 ```
 

--- a/extension/.ai/CHALLENGE.yaml
+++ b/extension/.ai/CHALLENGE.yaml
@@ -328,7 +328,7 @@ checkpoints:
 
         Say **"check"** when you're ready!
       file: "packages/circuits/src/main.nr"
-      test: "cd extension/packages/circuits && nargo check 2>&1 | grep -v warning && echo 'Circuit check passed!'"
+      test: "cd packages/circuits && nargo check 2>&1 | grep -v warning && echo 'Circuit check passed!'"
       hints:
         - "`hash_1` takes an array of one element: `hash_1([nullifier])`. `hash_2` takes an array of two: `hash_2([nullifier, secret])`."
         - |
@@ -447,7 +447,7 @@ checkpoints:
 
         Say **"check"** when you're ready!
       file: "packages/circuits/src/main.nr"
-      test: "cd extension/packages/circuits && nargo check 2>&1 | grep -v warning && echo 'Circuit check passed!'"
+      test: "cd packages/circuits && nargo check 2>&1 | grep -v warning && echo 'Circuit check passed!'"
       hints:
         - "Don't forget to uncomment BOTH the import at the top AND the function parameters. The parameters are commented out below the `////// Checkpoint 4 //////` comment in the function signature."
         - |
@@ -586,7 +586,7 @@ checkpoints:
 
         Say **"check"** when you're ready!
       file: "packages/circuits/src/main.nr"
-      test: "test -s extension/packages/circuits/target/Verifier.sol && grep -q 'function verify' extension/packages/circuits/target/Verifier.sol && echo 'Verifier contract generated!'"
+      test: "test -s packages/circuits/target/Verifier.sol && grep -q 'function verify' packages/circuits/target/Verifier.sol && echo 'Verifier contract generated!'"
       hints:
         - "Make sure you `cd packages/circuits` first. All three commands must be run from that directory."
         - |
@@ -913,7 +913,7 @@ checkpoints:
 
         Say **"check"** when you're ready!
       file: "packages/nextjs/app/voting/_challengeComponents/CreateCommitment.tsx"
-      test: "grep -q 'Fr.random' extension/packages/nextjs/app/voting/_challengeComponents/CreateCommitment.tsx && grep -q 'poseidon2' extension/packages/nextjs/app/voting/_challengeComponents/CreateCommitment.tsx && echo 'Commitment generation check passed!'"
+      test: "grep -q 'Fr.random' packages/nextjs/app/voting/_challengeComponents/CreateCommitment.tsx && grep -q 'poseidon2' packages/nextjs/app/voting/_challengeComponents/CreateCommitment.tsx && echo 'Commitment generation check passed!'"
       hints:
         - "Cast `Fr.random()` to BigInt: `const nullifier = BigInt(Fr.random().toString());`. Use `toHex(value, { size: 32 })` for the hex conversion."
         - |
@@ -1083,7 +1083,7 @@ checkpoints:
 
         Say **"check"** when you're ready!
       file: "packages/nextjs/app/voting/_challengeComponents/GenerateProof.tsx"
-      test: "grep -q 'new Noir' extension/packages/nextjs/app/voting/_challengeComponents/GenerateProof.tsx && grep -q 'UltraHonkBackend' extension/packages/nextjs/app/voting/_challengeComponents/GenerateProof.tsx && echo 'Proof generation check passed!'"
+      test: "grep -q 'new Noir' packages/nextjs/app/voting/_challengeComponents/GenerateProof.tsx && grep -q 'UltraHonkBackend' packages/nextjs/app/voting/_challengeComponents/GenerateProof.tsx && echo 'Proof generation check passed!'"
       hints:
         - 'Events are emitted newest-last. Reverse the leaves array before inserting into the tree: `leaves.reverse()`. Pad siblings to 16 with `"0"`.'
         - |
@@ -1247,7 +1247,7 @@ checkpoints:
 
         Say **"check"** when you're ready!
       file: "packages/nextjs/app/voting/_challengeComponents/VoteWithBurnerHardhat.tsx"
-      test: "grep -q 'generatePrivateKey' extension/packages/nextjs/app/voting/_challengeComponents/VoteWithBurnerHardhat.tsx && grep -q 'viemContract.write.vote' extension/packages/nextjs/app/voting/_challengeComponents/VoteWithBurnerHardhat.tsx && echo 'Burner wallet check passed!'"
+      test: "grep -q 'generatePrivateKey' packages/nextjs/app/voting/_challengeComponents/VoteWithBurnerHardhat.tsx && grep -q 'viemContract.write.vote' packages/nextjs/app/voting/_challengeComponents/VoteWithBurnerHardhat.tsx && echo 'Burner wallet check passed!'"
       hints:
         - "`generatePrivateKey()` from `viem/accounts` creates a random private key. `privateKeyToAccount(pk)` derives the address from it."
         - |

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -94,7 +94,7 @@ If you are using vscode you may want to install the [Noir Language Support](http
 Then download the challenge to your computer and install dependencies by running:
 
 \`\`\`javascript
-npx create-eth@2.0.18 -e scaffold-eth/se-2-challenges:challenge-zk-voting challenge-zk-voting
+npx create-eth@2.0.20 -e scaffold-eth/se-2-challenges:challenge-zk-voting challenge-zk-voting
 cd challenge-zk-voting
 \`\`\`
 

--- a/extension/packages/hardhat/contracts/Voting.sol
+++ b/extension/packages/hardhat/contracts/Voting.sol
@@ -1,8 +1,8 @@
 //SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
-import {LeanIMT, LeanIMTData} from "@zk-kit/lean-imt.sol/LeanIMT.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import { LeanIMT, LeanIMTData } from "@zk-kit/lean-imt.sol/LeanIMT.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 /// Checkpoint 6 //////
 // import {IVerifier} from "./Verifier.sol";
 

--- a/extension/packages/hardhat/contracts/mocks/VerifierMock.sol
+++ b/extension/packages/hardhat/contracts/mocks/VerifierMock.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 /// Checkpoint 6 //////
-import {IVerifier} from "../Verifier.sol";
+import { IVerifier } from "../Verifier.sol";
 
 contract VerifierMock is IVerifier {
     bool public shouldVerify = true;
@@ -40,8 +40,11 @@ contract VerifierMock is IVerifier {
         }
         if (enforceExpectedInputs) {
             if (
-                _publicInputs.length != 4 || _publicInputs[0] != expectedNullifier || _publicInputs[1] != expectedRoot
-                    || _publicInputs[2] != expectedVote || _publicInputs[3] != expectedDepth
+                _publicInputs.length != 4 ||
+                _publicInputs[0] != expectedNullifier ||
+                _publicInputs[1] != expectedRoot ||
+                _publicInputs[2] != expectedVote ||
+                _publicInputs[3] != expectedDepth
             ) {
                 return false;
             }

--- a/extension/packages/hardhat/deploy/00_deploy_your_voting_contract.ts
+++ b/extension/packages/hardhat/deploy/00_deploy_your_voting_contract.ts
@@ -34,25 +34,33 @@ export default deployScript(
     //   args: [],
     // });
 
-    // const leanIMT = await deploy("LeanIMT", {
-    //   account: deployer,
-    //   artifact: artifacts.LeanIMT,
-    //   args: [],
-    //   libraries: {
-    //     PoseidonT3: poseidon3.address,
+    // const leanIMT = await deploy(
+    //   "LeanIMT",
+    //   {
+    //     account: deployer,
+    //     artifact: artifacts.LeanIMT,
+    //     args: [],
     //   },
-    // });
+    //   {
+    //     libraries: {
+    //       PoseidonT3: poseidon3.address,
+    //     },
+    //   },
+    // );
 
-    await deploy("Voting", {
-      account: deployer,
-      artifact: artifacts.Voting,
-      /// checkpoint 6 //////
-      args: [ownerAddress, verifierAddress, "Should we build zk apps?"],
-      libraries: {
-        /// checkpoint 2 //////
-        LeanIMT: leanIMTAddress,
+    await deploy(
+      "Voting",
+      {
+        account: deployer,
+        artifact: artifacts.Voting,
+        args: [ownerAddress, verifierAddress, "Should we build zk apps?"],
       },
-    });
+      {
+        libraries: {
+          LeanIMT: leanIMTAddress,
+        },
+      },
+    );
   },
   // Tags are useful if you have multiple deploy files and only want to run one of them.
   // e.g. yarn deploy --tags YourVotingContract

--- a/extension/packages/hardhat/deploy/00_deploy_your_voting_contract.ts
+++ b/extension/packages/hardhat/deploy/00_deploy_your_voting_contract.ts
@@ -1,71 +1,60 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
+import { artifacts, deployScript } from "../rocketh/deploy.js";
 
 /**
- * Deploys a contract named "YourContract" using the deployer account and
- * constructor arguments set to the deployer address
+ * Deploys a contract named "Voting" using the deployer account.
  *
- * @param hre HardhatRuntimeEnvironment object.
+ * On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+ *
+ * When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
+ * should have sufficient balance to pay for the gas fees for contract creation.
+ *
+ * You can generate a random account with `yarn generate` or `yarn account:import` to import your
+ * existing PK which will fill DEPLOYER_PRIVATE_KEY_ENCRYPTED in the .env file (used in hardhat.config.ts).
+ * Run `yarn account` to check the deployer balance on every network.
  */
-const deployYourVotingContract: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  /*
-    On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+export default deployScript(
+  async ({ deploy, namedAccounts }) => {
+    const { deployer } = namedAccounts;
 
-    When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
-    should have sufficient balance to pay for the gas fees for contract creation.
+    const ownerAddress = "0x0000000000000000000000000000000000000001";
 
-    You can generate a random account with `yarn generate` or `yarn account:import` to import your
-    existing PK which will fill DEPLOYER_PRIVATE_KEY_ENCRYPTED in the .env file (then used on hardhat.config.ts)
-    You can run the `yarn account` command to check your balance in every network.
-  */
-  const { deployer } = await hre.getNamedAccounts();
-  const { deploy } = hre.deployments;
-
-  const ownerAddress = "0x0000000000000000000000000000000000000001";
-
-  /// checkpoint 6 //////
-  const verifierAddress = "0x0000000000000000000000000000000000000002"; // placeholder
-  // const verifier = await deploy("HonkVerifier", {
-  //   from: deployer,
-  //   log: true,
-  //   autoMine: true,
-  // });
-
-  /// checkpoint 2 //////
-  const leanIMTAddress = "0x0000000000000000000000000000000000000003"; // placeholder
-  // const poseidon3 = await deploy("PoseidonT3", {
-  //   from: deployer,
-  //   log: true,
-  //   autoMine: true,
-  // });
-
-  // const leanIMT = await deploy("LeanIMT", {
-  //   from: deployer,
-  //   log: true,
-  //   autoMine: true,
-  //   libraries: {
-  //     PoseidonT3: poseidon3.address,
-  //   },
-  // });
-
-  await deploy("Voting", {
-    from: deployer,
-    // Contract constructor arguments
     /// checkpoint 6 //////
-    args: [ownerAddress, verifierAddress, "Should we build zk apps?"],
-    log: true,
-    // autoMine: can be passed to the deploy function to make the deployment process faster on local networks by
-    // automatically mining the contract deployment transaction. There is no effect on live networks.
-    autoMine: true,
-    libraries: {
-      /// checkpoint 2 //////
-      LeanIMT: leanIMTAddress,
-    },
-  });
-};
+    const verifierAddress = "0x0000000000000000000000000000000000000002"; // placeholder
+    // const verifier = await deploy("HonkVerifier", {
+    //   account: deployer,
+    //   artifact: artifacts.HonkVerifier,
+    //   args: [],
+    // });
 
-export default deployYourVotingContract;
+    /// checkpoint 2 //////
+    const leanIMTAddress = "0x0000000000000000000000000000000000000003"; // placeholder
+    // const poseidon3 = await deploy("PoseidonT3", {
+    //   account: deployer,
+    //   artifact: artifacts.PoseidonT3,
+    //   args: [],
+    // });
 
-// Tags are useful if you have multiple deploy files and only want to run one of them.
-// e.g. yarn deploy --tags YourContract
-deployYourVotingContract.tags = ["YourVotingContract"];
+    // const leanIMT = await deploy("LeanIMT", {
+    //   account: deployer,
+    //   artifact: artifacts.LeanIMT,
+    //   args: [],
+    //   libraries: {
+    //     PoseidonT3: poseidon3.address,
+    //   },
+    // });
+
+    await deploy("Voting", {
+      account: deployer,
+      artifact: artifacts.Voting,
+      /// checkpoint 6 //////
+      args: [ownerAddress, verifierAddress, "Should we build zk apps?"],
+      libraries: {
+        /// checkpoint 2 //////
+        LeanIMT: leanIMTAddress,
+      },
+    });
+  },
+  // Tags are useful if you have multiple deploy files and only want to run one of them.
+  // e.g. yarn deploy --tags YourVotingContract
+  { tags: ["YourVotingContract"] },
+);

--- a/extension/packages/hardhat/hardhat.config.ts.args.mjs
+++ b/extension/packages/hardhat/hardhat.config.ts.args.mjs
@@ -13,6 +13,7 @@ export const configOverrides = {
       },
     ],
   },
+  npmFilesToBuild: ["poseidon-solidity/PoseidonT3.sol", "@zk-kit/lean-imt.sol/LeanIMT.sol"],
   networks: {
     hardhat: {
       allowUnlimitedContractSize: true,

--- a/extension/packages/hardhat/hardhat.config.ts.args.mjs
+++ b/extension/packages/hardhat/hardhat.config.ts.args.mjs
@@ -12,8 +12,8 @@ export const configOverrides = {
         },
       },
     ],
+    npmFilesToBuild: ["poseidon-solidity/PoseidonT3.sol", "@zk-kit/lean-imt.sol/LeanIMT.sol"],
   },
-  npmFilesToBuild: ["poseidon-solidity/PoseidonT3.sol", "@zk-kit/lean-imt.sol/LeanIMT.sol"],
   networks: {
     hardhat: {
       allowUnlimitedContractSize: true,

--- a/extension/packages/hardhat/test/Voting.ts
+++ b/extension/packages/hardhat/test/Voting.ts
@@ -31,10 +31,14 @@ describe("🗳️ ZK Voting Challenge", function () {
       await leanIMT.waitForDeployment();
 
       const VotingFactory = await ethers.getContractFactory(contractArtifact, {
-        libraries: { "@zk-kit/lean-imt.sol/LeanIMT.sol:LeanIMT": await leanIMT.getAddress() },
+        libraries: { LeanIMT: await leanIMT.getAddress() },
       });
       const verifierZero = "0x0000000000000000000000000000000000000000";
-      const voting = (await VotingFactory.deploy(owner.address, verifierZero, "Should we build zk apps?")) as unknown as Voting;
+      const voting = (await VotingFactory.deploy(
+        owner.address,
+        verifierZero,
+        "Should we build zk apps?",
+      )) as unknown as Voting;
       await voting.waitForDeployment();
 
       return { voting, owner, alice, bob };
@@ -58,7 +62,7 @@ describe("🗳️ ZK Voting Challenge", function () {
       await voting.connect(owner).addVoters([alice.address, bob.address], [true, true]);
 
       const duplicateCommitment = 222n;
-      await expect(voting.connect(alice).register(duplicateCommitment)).to.not.be.reverted;
+      await expect(voting.connect(alice).register(duplicateCommitment)).to.not.be.revert(ethers);
       await expect(voting.connect(bob).register(duplicateCommitment))
         .to.be.revertedWithCustomError(voting, "Voting__CommitmentAlreadyAdded")
         .withArgs(duplicateCommitment);
@@ -69,7 +73,7 @@ describe("🗳️ ZK Voting Challenge", function () {
 
       await voting.connect(owner).addVoters([alice.address], [true]);
 
-      await expect(voting.connect(alice).register(333n)).to.not.be.reverted;
+      await expect(voting.connect(alice).register(333n)).to.not.be.revert(ethers);
       await expect(voting.connect(alice).register(444n)).to.be.revertedWithCustomError(
         voting,
         "Voting__NotAllowedToVote",
@@ -121,9 +125,13 @@ describe("🗳️ ZK Voting Challenge", function () {
       await verifier.waitForDeployment();
 
       const VotingFactory = await ethers.getContractFactory(contractArtifact, {
-        libraries: { "@zk-kit/lean-imt.sol/LeanIMT.sol:LeanIMT": await leanIMT.getAddress() },
+        libraries: { LeanIMT: await leanIMT.getAddress() },
       });
-      const voting = (await VotingFactory.deploy(owner.address, await verifier.getAddress(), "Question?")) as unknown as Voting;
+      const voting = (await VotingFactory.deploy(
+        owner.address,
+        await verifier.getAddress(),
+        "Question?",
+      )) as unknown as Voting;
       await voting.waitForDeployment();
 
       // allowlist and register a voter to set a non-zero root

--- a/extension/packages/hardhat/test/Voting.ts
+++ b/extension/packages/hardhat/test/Voting.ts
@@ -1,9 +1,15 @@
 import { expect } from "chai";
-import { ethers } from "hardhat";
-import type { Voting } from "../typechain-types";
-import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
+import { network } from "hardhat";
+import type { Voting } from "../types/ethers-contracts/index.js";
+import { anyValue } from "@nomicfoundation/hardhat-ethers-chai-matchers/withArgs";
 
 describe("🗳️ ZK Voting Challenge", function () {
+  let ethers: Awaited<ReturnType<typeof network.create>>["ethers"];
+
+  before(async function () {
+    ({ ethers } = await network.create());
+  });
+
   let contractArtifact = "";
   if (process.env.CONTRACT_ADDRESS) {
     contractArtifact = `contracts/download-${process.env.CONTRACT_ADDRESS}.sol:Voting`;
@@ -28,7 +34,7 @@ describe("🗳️ ZK Voting Challenge", function () {
         libraries: { "@zk-kit/lean-imt.sol/LeanIMT.sol:LeanIMT": await leanIMT.getAddress() },
       });
       const verifierZero = "0x0000000000000000000000000000000000000000";
-      const voting = (await VotingFactory.deploy(owner.address, verifierZero, "Should we build zk apps?")) as Voting;
+      const voting = (await VotingFactory.deploy(owner.address, verifierZero, "Should we build zk apps?")) as unknown as Voting;
       await voting.waitForDeployment();
 
       return { voting, owner, alice, bob };
@@ -117,7 +123,7 @@ describe("🗳️ ZK Voting Challenge", function () {
       const VotingFactory = await ethers.getContractFactory(contractArtifact, {
         libraries: { "@zk-kit/lean-imt.sol/LeanIMT.sol:LeanIMT": await leanIMT.getAddress() },
       });
-      const voting = (await VotingFactory.deploy(owner.address, await verifier.getAddress(), "Question?")) as Voting;
+      const voting = (await VotingFactory.deploy(owner.address, await verifier.getAddress(), "Question?")) as unknown as Voting;
       await voting.waitForDeployment();
 
       // allowlist and register a voter to set a non-zero root

--- a/extension/packages/nextjs/app/voting/_challengeComponents/CreateCommitment.tsx
+++ b/extension/packages/nextjs/app/voting/_challengeComponents/CreateCommitment.tsx
@@ -3,8 +3,8 @@
 import { useState } from "react";
 ////// Checkpoint 7 //////
 // import { Fr } from "@aztec/bb.js";
-// import { toHex } from "viem";
 // import { poseidon2 } from "poseidon-lite";
+// import { toHex } from "viem";
 import { useAccount } from "wagmi";
 import { useDeployedContractInfo, useScaffoldReadContract, useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
 import { useChallengeState } from "~~/services/store/challengeStore";

--- a/extension/packages/nextjs/app/voting/_challengeComponents/GenerateProof.tsx
+++ b/extension/packages/nextjs/app/voting/_challengeComponents/GenerateProof.tsx
@@ -6,7 +6,6 @@ import { useState } from "react";
 // // @ts-ignore
 // import { Noir } from "@noir-lang/noir_js";
 // import { LeanIMT } from "@zk-kit/lean-imt";
-// import { encodeAbiParameters, toHex } from "viem";
 // import { poseidon1, poseidon2 } from "poseidon-lite";
 import { useAccount } from "wagmi";
 import { useDeployedContractInfo, useScaffoldReadContract } from "~~/hooks/scaffold-eth";

--- a/extension/packages/nextjs/app/voting/_challengeComponents/VoteWithBurnerHardhat.tsx
+++ b/extension/packages/nextjs/app/voting/_challengeComponents/VoteWithBurnerHardhat.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Address } from "@scaffold-ui/components";
 import { createPublicClient, createWalletClient, getContract, http } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { hardhat } from "viem/chains";
 import { useAccount } from "wagmi";
-import { Address } from "@scaffold-ui/components";
 import { useDeployedContractInfo, useScaffoldEventHistory } from "~~/hooks/scaffold-eth";
 import { useChallengeState } from "~~/services/store/challengeStore";
 import {

--- a/extension/packages/nextjs/app/voting/_challengeComponents/VoteWithBurnerHardhat.tsx
+++ b/extension/packages/nextjs/app/voting/_challengeComponents/VoteWithBurnerHardhat.tsx
@@ -16,7 +16,7 @@ import {
 } from "~~/utils/proofStorage";
 
 ////// Checkpoint 9 //////
-// import {  parseEther, createTestClient } from "viem";
+// import { createTestClient, parseEther } from "viem";
 // import { generatePrivateKey } from "viem/accounts";
 
 type LocalProofData = {

--- a/extension/packages/nextjs/app/voting/_challengeComponents/VoteWithBurnerSepolia.tsx
+++ b/extension/packages/nextjs/app/voting/_challengeComponents/VoteWithBurnerSepolia.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Address } from "@scaffold-ui/components";
 import { createSmartAccountClient } from "permissionless";
 import { toSafeSmartAccount } from "permissionless/accounts";
 import { createPimlicoClient } from "permissionless/clients/pimlico";
@@ -9,7 +10,6 @@ import { EntryPointVersion, entryPoint07Address } from "viem/account-abstraction
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
 import { useAccount } from "wagmi";
-import { Address } from "@scaffold-ui/components";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
 import { useChallengeState } from "~~/services/store/challengeStore";
 import {

--- a/extension/packages/nextjs/app/voting/_components/AddVotersModal.tsx
+++ b/extension/packages/nextjs/app/voting/_components/AddVotersModal.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState } from "react";
+import { AddressInput } from "@scaffold-ui/components";
 import { useAccount } from "wagmi";
 import { PlusIcon, TrashIcon, UserPlusIcon } from "@heroicons/react/24/outline";
-import { AddressInput } from "@scaffold-ui/components";
 import { useScaffoldReadContract, useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
 
 type VoterEntry = {

--- a/extension/packages/nextjs/app/voting/_components/ShowVotersButton.tsx
+++ b/extension/packages/nextjs/app/voting/_components/ShowVotersButton.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
-import { EyeIcon, UsersIcon } from "@heroicons/react/24/outline";
 import { Address } from "@scaffold-ui/components";
+import { EyeIcon, UsersIcon } from "@heroicons/react/24/outline";
 import { useScaffoldEventHistory, useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 
 export const ShowVotersButton = () => {

--- a/extension/packages/nextjs/next.config.ts.args.mjs
+++ b/extension/packages/nextjs/next.config.ts.args.mjs
@@ -2,7 +2,4 @@ export const configOverrides = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
 };

--- a/extension/packages/nextjs/scaffold.config.ts.args.mjs
+++ b/extension/packages/nextjs/scaffold.config.ts.args.mjs
@@ -4,5 +4,5 @@
 // Default args:
 export const preContent = "";
 export const extraConfigTypeName = "";
-export const configOverrides = { targetNetworks: [], onlyLocalBurnerWallet: false };
+export const configOverrides = { targetNetworks: [], burnerWalletMode: "allNetworks" };
 export const skipLocalChainInTargetNetworks = false;


### PR DESCRIPTION
## Summary
- Migrate Voting deploy to `rocketh`'s `deployScript` (preserving the commented checkpoint scaffolding for HonkVerifier / PoseidonT3 / LeanIMT).
- Migrate Voting test: `network.create()` in `before` hook, type-only imports, cast deploys with `as unknown as`.
- Switch `@nomicfoundation/hardhat-chai-matchers/withArgs` → `@nomicfoundation/hardhat-ethers-chai-matchers/withArgs`.
- Remove `eslint.ignoreDuringBuilds` from `next.config.ts.args.mjs`.

## Test plan
- [ ] `yarn deploy` deploys `Voting` with library link to a placeholder LeanIMT (uncomment checkpoint scaffold to deploy the real libraries)
- [ ] `yarn hardhat:test` passes