### PR TITLE
feat: over-collateralized-lending migration to hh v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Deploy your contracts to a testnet then build and upload your app to a public we
 📥 Then download the challenge to your computer and install dependencies by running:
 
 ```sh
-npx create-eth@2.0.18 -e challenge-over-collateralized-lending challenge-over-collateralized-lending
+npx create-eth@2.0.20 -e challenge-over-collateralized-lending challenge-over-collateralized-lending
 cd challenge-over-collateralized-lending
 ```
 

--- a/extension/packages/hardhat/deploy/00_deploy_contracts.ts
+++ b/extension/packages/hardhat/deploy/00_deploy_contracts.ts
@@ -45,7 +45,7 @@ export default deployScript(
     // Only set up contract state on local network
     if (env.name === "default" || env.name === "localhost") {
       // Give ETH and CORN to the move price contract
-      await env.network.provider.request({
+      await env.network.provider.request<{ params: [`0x${string}`, `0x${string}`]; result: null }>({
         method: "hardhat_setBalance",
         params: [movePrice.address, `0x${parseEther("10000000000000000000000").toString(16)}`],
       });
@@ -66,7 +66,7 @@ export default deployScript(
         args: [deployer, parseEther("1000000000000")],
         account: deployer,
       });
-      await env.network.provider.request({
+      await env.network.provider.request<{ params: [`0x${string}`, `0x${string}`]; result: null }>({
         method: "hardhat_setBalance",
         params: [deployer, `0x${parseEther("100000000000").toString(16)}`],
       });

--- a/extension/packages/hardhat/deploy/00_deploy_contracts.ts
+++ b/extension/packages/hardhat/deploy/00_deploy_contracts.ts
@@ -1,81 +1,88 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { Contract } from "ethers";
+import { artifacts, deployScript } from "../rocketh/deploy.js";
+import { parseEther } from "viem";
 
 /**
- * Deploys a contract named "YourContract" using the deployer account and
- * constructor arguments set to the deployer address
+ * Deploys "Corn", "CornDEX", "Lending" and "MovePrice" using the deployer account.
  *
- * @param hre HardhatRuntimeEnvironment object.
+ * On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+ *
+ * When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
+ * should have sufficient balance to pay for the gas fees for contract creation.
+ *
+ * You can generate a random account with `yarn generate` or `yarn account:import` to import your
+ * existing PK which will fill DEPLOYER_PRIVATE_KEY_ENCRYPTED in the .env file (used in hardhat.config.ts).
+ * Run `yarn account` to check the deployer balance on every network.
  */
-const deployContracts: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  /*
-    On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+export default deployScript(
+  async env => {
+    const { deployer } = env.namedAccounts;
 
-    When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
-    should have sufficient balance to pay for the gas fees for contract creation.
+    const cornToken = await env.deploy("Corn", {
+      account: deployer,
+      artifact: artifacts.Corn,
+      args: [],
+    });
 
-    You can generate a random account with `yarn generate` or `yarn account:import` to import your
-    existing PK which will fill DEPLOYER_PRIVATE_KEY_ENCRYPTED in the .env file (then used on hardhat.config.ts)
-    You can run the `yarn account` command to check your balance in every network.
-  */
-  const { deployer } = await hre.getNamedAccounts();
-  const { deploy } = hre.deployments;
+    const cornDEX = await env.deploy("CornDEX", {
+      account: deployer,
+      artifact: artifacts.CornDEX,
+      args: [cornToken.address],
+    });
 
-  await deploy("Corn", {
-    from: deployer,
-    // Contract constructor arguments
-    args: [],
-    log: true,
-    // autoMine: can be passed to the deploy function to make the deployment process faster on local networks by
-    // automatically mining the contract deployment transaction. There is no effect on live networks.
-    autoMine: true,
-  });
-  const cornToken = await hre.ethers.getContract<Contract>("Corn", deployer);
+    const lending = await env.deploy("Lending", {
+      account: deployer,
+      artifact: artifacts.Lending,
+      args: [cornDEX.address, cornToken.address],
+    });
 
-  await deploy("CornDEX", {
-    from: deployer,
-    args: [cornToken.target],
-    log: true,
-    autoMine: true,
-  });
-  const cornDEX = await hre.ethers.getContract<Contract>("CornDEX", deployer);
-  const lending = await deploy("Lending", {
-    from: deployer,
-    args: [cornDEX.target, cornToken.target],
-    log: true,
-    autoMine: true,
-  });
+    // Set up the move price contract
+    const movePrice = await env.deploy("MovePrice", {
+      account: deployer,
+      artifact: artifacts.MovePrice,
+      args: [cornDEX.address, cornToken.address],
+    });
 
-  // Set up the move price contract
-  const movePrice = await deploy("MovePrice", {
-    from: deployer,
-    args: [cornDEX.target, cornToken.target],
-    log: true,
-    autoMine: true,
-  });
+    // Only set up contract state on local network
+    if (env.name === "default" || env.name === "localhost") {
+      // Give ETH and CORN to the move price contract
+      await env.network.provider.request({
+        method: "hardhat_setBalance",
+        params: [movePrice.address, `0x${parseEther("10000000000000000000000").toString(16)}`],
+      });
+      await env.execute(cornToken, {
+        functionName: "mintTo",
+        args: [movePrice.address, parseEther("10000000000000000000000")],
+        account: deployer,
+      });
+      // Lenders deposit CORN to the lending contract
+      await env.execute(cornToken, {
+        functionName: "mintTo",
+        args: [lending.address, parseEther("10000000000000000000000")],
+        account: deployer,
+      });
+      // Give CORN and ETH to the deployer
+      await env.execute(cornToken, {
+        functionName: "mintTo",
+        args: [deployer, parseEther("1000000000000")],
+        account: deployer,
+      });
+      await env.network.provider.request({
+        method: "hardhat_setBalance",
+        params: [deployer, `0x${parseEther("100000000000").toString(16)}`],
+      });
 
-  // Only set up contract state on local network
-  if (hre.network.name == "localhost") {
-    const GAS_LIMIT = 500_000n;
-    // Give ETH and CORN to the move price contract
-    await hre.ethers.provider.send("hardhat_setBalance", [
-      movePrice.address,
-      `0x${hre.ethers.parseEther("10000000000000000000000").toString(16)}`,
-    ]);
-    await cornToken.mintTo(movePrice.address, hre.ethers.parseEther("10000000000000000000000"), { gasLimit: GAS_LIMIT });
-    // Lenders deposit CORN to the lending contract
-    await cornToken.mintTo(lending.address, hre.ethers.parseEther("10000000000000000000000"), { gasLimit: GAS_LIMIT });
-    // Give CORN and ETH to the deployer
-    await cornToken.mintTo(deployer, hre.ethers.parseEther("1000000000000"), { gasLimit: GAS_LIMIT });
-    await hre.ethers.provider.send("hardhat_setBalance", [
-      deployer,
-      `0x${hre.ethers.parseEther("100000000000").toString(16)}`,
-    ]);
-
-    await cornToken.approve(cornDEX.target, hre.ethers.parseEther("1000000000"), { gasLimit: GAS_LIMIT });
-    await cornDEX.init(hre.ethers.parseEther("1000000000"), { value: hre.ethers.parseEther("1000000"), gasLimit: GAS_LIMIT });
-  }
-};
-
-export default deployContracts;
+      await env.execute(cornToken, {
+        functionName: "approve",
+        args: [cornDEX.address, parseEther("1000000000")],
+        account: deployer,
+      });
+      await env.execute(cornDEX, {
+        functionName: "init",
+        args: [parseEther("1000000000")],
+        value: parseEther("1000000"),
+        account: deployer,
+      });
+    }
+  },
+  { tags: ["Lending"] },
+);

--- a/extension/packages/hardhat/scripts/marketSimulator.ts
+++ b/extension/packages/hardhat/scripts/marketSimulator.ts
@@ -1,7 +1,18 @@
 import { HDNodeWallet, parseEther } from "ethers";
-import hre from "hardhat";
-import { CornDEX, Lending, Corn, MovePrice } from "../typechain-types";
-const ethers = hre.ethers;
+import { network } from "hardhat";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import type { CornDEX, Lending, Corn, MovePrice } from "../types/ethers-contracts/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const { ethers } = await network.create();
+
+function loadDeployment(name: string): { address: string; abi: any } {
+  const path = join(__dirname, `../deployments/default/${name}.json`);
+  return JSON.parse(readFileSync(path, "utf8"));
+}
 
 interface SimulatedAccount {
   wallet: HDNodeWallet;
@@ -63,6 +74,7 @@ async function simulateMarketActions(
   movePrice: MovePrice,
   lending: Lending,
   corn: Corn,
+  cornDEX: CornDEX,
   accounts: SimulatedAccount[],
   deployer: any,
 ) {
@@ -105,7 +117,7 @@ async function simulateMarketActions(
       }
 
       // 5. Check for and perform liquidations
-      await checkAndPerformLiquidations(lending, corn, accounts);
+      await checkAndPerformLiquidations(lending, corn, cornDEX, accounts);
     } catch (error) {
       console.error("Error in market simulation interval");
       if (process.env.DEBUG) {
@@ -136,8 +148,8 @@ async function simulateBorrowing(lending: Lending, accounts: SimulatedAccount[])
       await lendingWithAccount.borrowCorn(maxBorrowAmount);
       console.log(
         `Account ${randomAccount.wallet.address} borrowed ${ethers.formatEther(maxBorrowAmount)} CORN ` +
-          `(${aggressiveBorrower ? "aggressive" : "conservative"}, ` +
-          `${((Number(maxBorrowAmount) * 100) / Number(collateralValue)).toFixed(1)}% of collateral)`,
+        `(${aggressiveBorrower ? "aggressive" : "conservative"}, ` +
+        `${((Number(maxBorrowAmount) * 100) / Number(collateralValue)).toFixed(1)}% of collateral)`,
       );
     } catch (error) {
       if (process.env.DEBUG) {
@@ -166,8 +178,8 @@ async function simulateAddCollateral(lending: Lending, accounts: SimulatedAccoun
 
         console.log(
           `Account ${randomAccount.wallet.address} added ${ethers.formatEther(amountToAdd)} ETH as collateral ` +
-            `(${percentage.toFixed(1)}% of available balance, ` +
-            `total collateral: ${ethers.formatEther(currentCollateral + amountToAdd)} ETH)`,
+          `(${percentage.toFixed(1)}% of available balance, ` +
+          `total collateral: ${ethers.formatEther(currentCollateral + amountToAdd)} ETH)`,
         );
       } catch (error) {
         if (process.env.DEBUG) {
@@ -178,9 +190,12 @@ async function simulateAddCollateral(lending: Lending, accounts: SimulatedAccoun
   }
 }
 
-async function checkAndPerformLiquidations(lending: Lending, corn: Corn, accounts: SimulatedAccount[]) {
-  const cornDEX = await ethers.getContract<CornDEX>("CornDEX");
-
+async function checkAndPerformLiquidations(
+  lending: Lending,
+  corn: Corn,
+  cornDEX: CornDEX,
+  accounts: SimulatedAccount[],
+) {
   const filter = lending.filters.CollateralAdded();
   const events = await lending.queryFilter(filter);
   const users = [...new Set(events.map(event => event.args[0]))];
@@ -195,18 +210,18 @@ async function checkAndPerformLiquidations(lending: Lending, corn: Corn, account
     if (!isLiquidatable) continue;
 
     const liquidators = accounts.filter(account => account.wallet.address.toLowerCase() !== user.toLowerCase());
-    
+
     const liquidatorsWithBalance = await Promise.all(
       liquidators.map(async account => {
         const cornBalance = await corn.balanceOf(account.wallet.address);
         return { account, hasEnough: cornBalance >= amountBorrowed };
-      })
+      }),
     );
 
     const eligibleLiquidators = liquidatorsWithBalance
       .filter(({ hasEnough }) => hasEnough)
       .map(({ account }) => account);
-      
+
     if (eligibleLiquidators.length === 0) {
       const randomAccount = accounts[Math.floor(Math.random() * accounts.length)];
       if (randomAccount.wallet.address.toLowerCase() !== user.toLowerCase()) {
@@ -277,14 +292,21 @@ async function checkAndPerformLiquidations(lending: Lending, corn: Corn, account
 
 async function main() {
   const [deployer] = await ethers.getSigners();
-  const movePriceContract = await ethers.getContract<MovePrice>("MovePrice", deployer);
-  const lending = await ethers.getContract<Lending>("Lending", deployer);
-  const corn = await ethers.getContract<Corn>("Corn", deployer);
+
+  const movePriceDep = loadDeployment("MovePrice");
+  const lendingDep = loadDeployment("Lending");
+  const cornDep = loadDeployment("Corn");
+  const cornDEXDep = loadDeployment("CornDEX");
+
+  const movePriceContract = new ethers.Contract(movePriceDep.address, movePriceDep.abi, deployer) as unknown as MovePrice;
+  const lending = new ethers.Contract(lendingDep.address, lendingDep.abi, deployer) as unknown as Lending;
+  const corn = new ethers.Contract(cornDep.address, cornDep.abi, deployer) as unknown as Corn;
+  const cornDEX = new ethers.Contract(cornDEXDep.address, cornDEXDep.abi, deployer) as unknown as CornDEX;
 
   const accounts = await setupAccounts();
 
   // Start the combined market simulation
-  await simulateMarketActions(movePriceContract, lending, corn, accounts, deployer);
+  await simulateMarketActions(movePriceContract, lending, corn, cornDEX, accounts, deployer);
 
   // Keep the script running
   process.stdin.resume();

--- a/extension/packages/hardhat/scripts/marketSimulator.ts
+++ b/extension/packages/hardhat/scripts/marketSimulator.ts
@@ -9,6 +9,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const { ethers } = await network.create();
 
+// This script only runs against the local chain: it reads contract addresses
+// from the `default` deployments folder written by the local `yarn deploy`.
 function loadDeployment(name: string): { address: string; abi: any } {
   const path = join(__dirname, `../deployments/default/${name}.json`);
   return JSON.parse(readFileSync(path, "utf8"));
@@ -298,7 +300,11 @@ async function main() {
   const cornDep = loadDeployment("Corn");
   const cornDEXDep = loadDeployment("CornDEX");
 
-  const movePriceContract = new ethers.Contract(movePriceDep.address, movePriceDep.abi, deployer) as unknown as MovePrice;
+  const movePriceContract = new ethers.Contract(
+    movePriceDep.address,
+    movePriceDep.abi,
+    deployer,
+  ) as unknown as MovePrice;
   const lending = new ethers.Contract(lendingDep.address, lendingDep.abi, deployer) as unknown as Lending;
   const corn = new ethers.Contract(cornDep.address, cornDep.abi, deployer) as unknown as Corn;
   const cornDEX = new ethers.Contract(cornDEXDep.address, cornDEXDep.abi, deployer) as unknown as CornDEX;

--- a/extension/packages/hardhat/test/Lending.ts
+++ b/extension/packages/hardhat/test/Lending.ts
@@ -2,32 +2,41 @@
 // This script executes when you run 'yarn test'
 //
 
-import { ethers } from "hardhat";
+import { network } from "hardhat";
 import { expect } from "chai";
-import { Corn, CornDEX, Lending } from "../typechain-types";
-import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import type { Corn, CornDEX, Lending } from "../types/ethers-contracts/index.js";
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types";
 
 describe("💳🌽 Over-collateralized Lending Challenge 🤓", function () {
+  let ethers: Awaited<ReturnType<typeof network.create>>["ethers"];
+  let provider: Awaited<ReturnType<typeof network.create>>["provider"];
+
   const contractAddress = process.env.CONTRACT_ADDRESS;
   let cornToken: Corn;
   let cornDEX: CornDEX;
   let lending: Lending;
-  let owner: SignerWithAddress;
-  let user1: SignerWithAddress;
-  let user2: SignerWithAddress;
+  let owner: HardhatEthersSigner;
+  let user1: HardhatEthersSigner;
+  let user2: HardhatEthersSigner;
 
-  const collateralAmount = ethers.parseEther("10");
-  const borrowAmount = ethers.parseEther("5000");
+  let collateralAmount: bigint;
+  let borrowAmount: bigint;
+
+  before(async function () {
+    ({ ethers, provider } = await network.create());
+    collateralAmount = ethers.parseEther("10");
+    borrowAmount = ethers.parseEther("5000");
+  });
 
   beforeEach(async function () {
-    await ethers.provider.send("hardhat_reset", []);
+    await provider.request({ method: "hardhat_reset", params: [] });
     [owner, user1, user2] = await ethers.getSigners();
 
     const Corn = await ethers.getContractFactory("Corn");
-    cornToken = await Corn.deploy();
+    cornToken = (await Corn.deploy()) as unknown as Corn;
 
     const CornDEX = await ethers.getContractFactory("CornDEX");
-    cornDEX = await CornDEX.deploy(await cornToken.getAddress());
+    cornDEX = (await CornDEX.deploy(await cornToken.getAddress())) as unknown as CornDEX;
 
     await cornToken.mintTo(owner.address, ethers.parseEther("1000000"));
     await cornToken.approve(cornDEX.target, ethers.parseEther("1000000"));
@@ -42,7 +51,7 @@ describe("💳🌽 Over-collateralized Lending Challenge 🤓", function () {
     }
 
     const Lending = await ethers.getContractFactory(contractArtifact);
-    lending = (await Lending.deploy(cornDEX.target, cornToken.target)) as Lending;
+    lending = (await Lending.deploy(cornDEX.target, cornToken.target)) as unknown as Lending;
     await cornToken.mintTo(lending.target, ethers.parseEther("10000000000000000000000"));
   });
 

--- a/extension/packages/hardhat/test/Lending.ts
+++ b/extension/packages/hardhat/test/Lending.ts
@@ -29,7 +29,7 @@ describe("💳🌽 Over-collateralized Lending Challenge 🤓", function () {
   });
 
   beforeEach(async function () {
-    await provider.request({ method: "hardhat_reset", params: [] });
+    ({ ethers, provider } = await network.create());
     [owner, user1, user2] = await ethers.getSigners();
 
     const Corn = await ethers.getContractFactory("Corn");

--- a/extension/packages/hardhat/test/Lending.ts
+++ b/extension/packages/hardhat/test/Lending.ts
@@ -4,12 +4,12 @@
 
 import { network } from "hardhat";
 import { expect } from "chai";
+import { parseEther } from "ethers";
 import type { Corn, CornDEX, Lending } from "../types/ethers-contracts/index.js";
 import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types";
 
 describe("💳🌽 Over-collateralized Lending Challenge 🤓", function () {
   let ethers: Awaited<ReturnType<typeof network.create>>["ethers"];
-  let provider: Awaited<ReturnType<typeof network.create>>["provider"];
 
   const contractAddress = process.env.CONTRACT_ADDRESS;
   let cornToken: Corn;
@@ -19,17 +19,11 @@ describe("💳🌽 Over-collateralized Lending Challenge 🤓", function () {
   let user1: HardhatEthersSigner;
   let user2: HardhatEthersSigner;
 
-  let collateralAmount: bigint;
-  let borrowAmount: bigint;
-
-  before(async function () {
-    ({ ethers, provider } = await network.create());
-    collateralAmount = ethers.parseEther("10");
-    borrowAmount = ethers.parseEther("5000");
-  });
+  const collateralAmount = parseEther("10");
+  const borrowAmount = parseEther("5000");
 
   beforeEach(async function () {
-    ({ ethers, provider } = await network.create());
+    ({ ethers } = await network.create());
     [owner, user1, user2] = await ethers.getSigners();
 
     const Corn = await ethers.getContractFactory("Corn");

--- a/extension/packages/nextjs/next.config.ts.args.mjs
+++ b/extension/packages/nextjs/next.config.ts.args.mjs
@@ -2,7 +2,4 @@ export const configOverrides = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
 };


### PR DESCRIPTION
## Summary
- Migrate deploy to `rocketh`'s `deployScript`. Uses `env.execute` for `mintTo` / `approve` / `init` calls and `env.network.provider.request` for `hardhat_setBalance`.
- Replace `hre.network.name == "localhost"` check with `env.name === "default" || env.name === "localhost"` since rocketh uses the "default" network alias for the local RPC.
- Migrate test: `network.create()` in `before`, destructure `provider` for `hardhat_reset`, `HardhatEthersSigner` import path `/signers` → `/types`, cast deploys with `as unknown as`.
- Remove `eslint.ignoreDuringBuilds` from `next.config.ts.args.mjs`.

## Test plan
- [ ] `yarn deploy` deploys Corn / CornDEX / Lending / MovePrice and seeds local state
- [ ] `yarn hardhat:test` passes