### PR TITLE
feat: stablecoins migration to hh v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Deploy your contracts to a testnet then build and upload your app to a public we
 📥 Then download the challenge to your computer and install dependencies by running:
 
 ```sh
-npx create-eth@2.0.18 -e scaffold-eth/se-2-challenges:challenge-stablecoins challenge-stablecoins
+npx create-eth@2.0.20 -e scaffold-eth/se-2-challenges:challenge-stablecoins challenge-stablecoins
 cd challenge-stablecoins
 ```
 

--- a/extension/packages/hardhat/deploy/00_deploy_contracts.ts
+++ b/extension/packages/hardhat/deploy/00_deploy_contracts.ts
@@ -1,131 +1,151 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { Contract } from "ethers";
-import { fetchPriceFromUniswap } from "../scripts/fetchPriceFromUniswap";
+import { artifacts, deployScript } from "../rocketh/deploy.js";
+import { parseEther, getContractAddress } from "viem";
+import { fetchPriceFromUniswap } from "../scripts/fetchPriceFromUniswap.js";
 
 /**
- * Deploys a contract named "YourContract" using the deployer account and
- * constructor arguments set to the deployer address
+ * Deploys "RateController", "MyUSD", "DEX", "Oracle", "MyUSDStaking" and "MyUSDEngine" using the deployer account.
  *
- * @param hre HardhatRuntimeEnvironment object.
+ * On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+ *
+ * When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
+ * should have sufficient balance to pay for the gas fees for contract creation.
+ *
+ * You can generate a random account with `yarn generate` or `yarn account:import` to import your
+ * existing PK which will fill DEPLOYER_PRIVATE_KEY_ENCRYPTED in the .env file (used in hardhat.config.ts).
+ * Run `yarn account` to check the deployer balance on every network.
  */
-const deployContracts: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  /*
-    On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+export default deployScript(
+  async env => {
+    const { deployer } = env.namedAccounts;
 
-    When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
-    should have sufficient balance to pay for the gas fees for contract creation.
+    const ethPrice = await fetchPriceFromUniswap();
 
-    You can generate a random account with `yarn generate` or `yarn account:import` to import your
-    existing PK which will fill DEPLOYER_PRIVATE_KEY_ENCRYPTED in the .env file (then used on hardhat.config.ts)
-    You can run the `yarn account` command to check your balance in every network.
-  */
-  const { deployer } = await hre.getNamedAccounts();
-  const { deploy } = hre.deployments;
+    // Add the account that you want to be the owner of your contracts when deployment is complete
+    const CONTRACT_OWNER = deployer; // Change this if you want to update the rates with a different account than the deployer
 
-  const ethPrice = await fetchPriceFromUniswap();
+    // Get the deployer's current nonce
+    const nonceHex = (await env.network.provider.request({
+      method: "eth_getTransactionCount",
+      params: [deployer, "pending"],
+    })) as `0x${string}`;
+    const deployerNonce = Number(BigInt(nonceHex));
 
-  // Add the account that you want to be the owner of your contracts when deployment is complete
-  const CONTRACT_OWNER = deployer; // Change this if you want to update the rates with a different account than the deployer
+    // Calculate future addresses based on nonce
+    const futureStakingAddress = getContractAddress({
+      from: deployer,
+      nonce: BigInt(deployerNonce + 4), // +4 because it will be our fifth deployment (after MyUSD, DEX, Oracle, RateController)
+    });
 
-  // Get the deployer's current nonce
-  const deployerNonce = await hre.ethers.provider.getTransactionCount(deployer);
+    const futureEngineAddress = getContractAddress({
+      from: deployer,
+      nonce: BigInt(deployerNonce + 5), // +5 because it will be our sixth deployment (after MyUSD, DEX, Oracle, Staking, RateController)
+    });
 
-  // Calculate future addresses based on nonce
-  const futureStakingAddress = hre.ethers.getCreateAddress({
-    from: deployer,
-    nonce: deployerNonce + 4, // +4 because it will be our fifth deployment (after MyUSD, DEX, Oracle, RateController)
-  });
+    const rateController = await env.deploy("RateController", {
+      account: deployer,
+      artifact: artifacts.RateController,
+      args: [futureEngineAddress, futureStakingAddress],
+    });
 
-  const futureEngineAddress = hre.ethers.getCreateAddress({
-    from: deployer,
-    nonce: deployerNonce + 5, // +5 because it will be our sixth deployment (after MyUSD, DEX, Oracle, Staking, RateController)
-  });
+    const stablecoin = await env.deploy("MyUSD", {
+      account: deployer,
+      artifact: artifacts.MyUSD,
+      args: [futureEngineAddress, futureStakingAddress],
+    });
 
-  await deploy("RateController", {
-    from: deployer,
-    args: [futureEngineAddress, futureStakingAddress],
-    log: true,
-  });
-  const rateController = await hre.ethers.getContract<Contract>("RateController", deployer);
+    const DEX = await env.deploy("DEX", {
+      account: deployer,
+      artifact: artifacts.DEX,
+      args: [stablecoin.address],
+    });
 
-  await deploy("MyUSD", {
-    from: deployer,
-    args: [futureEngineAddress, futureStakingAddress],
-    log: true,
-  });
-  const stablecoin = await hre.ethers.getContract<Contract>("MyUSD", deployer);
+    const oracle = await env.deploy("Oracle", {
+      account: deployer,
+      artifact: artifacts.Oracle,
+      args: [DEX.address, ethPrice],
+    });
 
-  await deploy("DEX", {
-    from: deployer,
-    args: [stablecoin.target],
-    log: true,
-  });
-  const DEX = await hre.ethers.getContract<Contract>("DEX", deployer);
+    const staking = await env.deploy("MyUSDStaking", {
+      account: deployer,
+      artifact: artifacts.MyUSDStaking,
+      args: [stablecoin.address, futureEngineAddress, rateController.address],
+    });
 
-  await deploy("Oracle", {
-    from: deployer,
-    args: [DEX.target, ethPrice],
-    log: true,
-  });
-  const oracle = await hre.ethers.getContract<Contract>("Oracle", deployer);
+    // Finally deploy the engine at the predicted address
+    const engine = await env.deploy("MyUSDEngine", {
+      account: deployer,
+      artifact: artifacts.MyUSDEngine,
+      args: [oracle.address, stablecoin.address, staking.address, rateController.address],
+    });
 
-  await deploy("MyUSDStaking", {
-    from: deployer,
-    args: [stablecoin.target, futureEngineAddress, rateController.target],
-    log: true,
-  });
-  const staking = await hre.ethers.getContract<Contract>("MyUSDStaking", deployer);
-
-  // Finally deploy the engine at the predicted address
-  await deploy("MyUSDEngine", {
-    from: deployer,
-    args: [oracle.target, stablecoin.target, staking.target, rateController.target],
-    log: true,
-  });
-  const engine = await hre.ethers.getContract<Contract>("MyUSDEngine", deployer);
-
-  if (engine.target !== futureEngineAddress) {
-    throw new Error(
-      "Engine address does not match predicted address, did you add transactions above this line that would skew the nonce set for 'futureEngineAddress'?",
-    );
-  }
-
-  if (hre.network.name === "localhost") {
-    // Set deployer ETH balance
-    await hre.ethers.provider.send("hardhat_setBalance", [
-      deployer,
-      `0x${hre.ethers.parseEther("100000000000000000000").toString(16)}`,
-    ]);
-
-    // The deployer is going to provide liquidity to the DEX so that we can swap tokens
-    // First they will borrow stablecoins and then provide liquidity to the DEX
-    // We will make the deployer account deposit a tone of collateral so they are rarely at risk of liquidation
-    const ethCollateralAmount = hre.ethers.parseEther("10000000000000000000");
-    // Set initial price of stablecoin (as determined by DEX liquidity)
-    const ethDEXAmount = hre.ethers.parseEther("10000000");
-    const myUSDAmount = ethPrice * 10000000n;
-
-    const GAS_LIMIT = 500000;
-
-    // Borrow stablecoins
-    await engine.addCollateral({ value: ethCollateralAmount, gasLimit: GAS_LIMIT });
-    await engine.mintMyUSD(myUSDAmount, { gasLimit: GAS_LIMIT });
-
-    const confirmedBalance = await stablecoin.balanceOf(deployer);
-    // Don't add DEX liquidity if the deployer account doesn't have the stablecoins
-    if (confirmedBalance == myUSDAmount) {
-      // Approve DEX to use tokens and initialize DEX
-      await stablecoin.approve(DEX.target, myUSDAmount, { gasLimit: GAS_LIMIT });
-      await DEX.init(myUSDAmount, { value: ethDEXAmount, gasLimit: GAS_LIMIT });
+    if (engine.address.toLowerCase() !== futureEngineAddress.toLowerCase()) {
+      throw new Error(
+        "Engine address does not match predicted address, did you add transactions above this line that would skew the nonce set for 'futureEngineAddress'?",
+      );
     }
 
-    // Set the owner of the engine and staking contracts
-    if (CONTRACT_OWNER !== deployer) {
-      await engine.transferOwnership(CONTRACT_OWNER);
-      await staking.transferOwnership(CONTRACT_OWNER);
-    }
-  }
-};
+    if (env.name === "default" || env.name === "localhost") {
+      // Set deployer ETH balance
+      await env.network.provider.request({
+        method: "hardhat_setBalance",
+        params: [deployer, `0x${parseEther("100000000000000000000").toString(16)}`],
+      });
 
-export default deployContracts;
+      // The deployer is going to provide liquidity to the DEX so that we can swap tokens
+      // First they will borrow stablecoins and then provide liquidity to the DEX
+      // We will make the deployer account deposit a tone of collateral so they are rarely at risk of liquidation
+      const ethCollateralAmount = parseEther("10000000000000000000");
+      // Set initial price of stablecoin (as determined by DEX liquidity)
+      const ethDEXAmount = parseEther("10000000");
+      const myUSDAmount = ethPrice * 10000000n;
+
+      // Borrow stablecoins
+      await env.execute(engine, {
+        functionName: "addCollateral",
+        args: [],
+        value: ethCollateralAmount,
+        account: deployer,
+      });
+      await env.execute(engine, {
+        functionName: "mintMyUSD",
+        args: [myUSDAmount],
+        account: deployer,
+      });
+
+      const confirmedBalance = (await env.read(stablecoin, {
+        functionName: "balanceOf",
+        args: [deployer],
+      })) as bigint;
+      // Don't add DEX liquidity if the deployer account doesn't have the stablecoins
+      if (confirmedBalance === myUSDAmount) {
+        // Approve DEX to use tokens and initialize DEX
+        await env.execute(stablecoin, {
+          functionName: "approve",
+          args: [DEX.address, myUSDAmount],
+          account: deployer,
+        });
+        await env.execute(DEX, {
+          functionName: "init",
+          args: [myUSDAmount],
+          value: ethDEXAmount,
+          account: deployer,
+        });
+      }
+
+      // Set the owner of the engine and staking contracts
+      if (CONTRACT_OWNER !== deployer) {
+        await env.execute(engine, {
+          functionName: "transferOwnership",
+          args: [CONTRACT_OWNER],
+          account: deployer,
+        });
+        await env.execute(staking, {
+          functionName: "transferOwnership",
+          args: [CONTRACT_OWNER],
+          account: deployer,
+        });
+      }
+    }
+  },
+  { tags: ["MyUSDEngine"] },
+);

--- a/extension/packages/hardhat/deploy/00_deploy_contracts.ts
+++ b/extension/packages/hardhat/deploy/00_deploy_contracts.ts
@@ -86,9 +86,11 @@ export default deployScript(
 
     if (env.name === "default" || env.name === "localhost") {
       // Set deployer ETH balance
-      await env.network.provider.request({
+      // hardhat_setBalance is not part of the provider's typed RPC schema, so we
+      // override the schema to type the params for this single call.
+      await env.network.provider.request<{ params: [string, string]; result: null }>({
         method: "hardhat_setBalance",
-        params: [deployer, `0x${parseEther("100000000000000000000").toString(16)}`] as never,
+        params: [deployer, `0x${parseEther("100000000000000000000").toString(16)}`],
       });
 
       // The deployer is going to provide liquidity to the DEX so that we can swap tokens

--- a/extension/packages/hardhat/deploy/00_deploy_contracts.ts
+++ b/extension/packages/hardhat/deploy/00_deploy_contracts.ts
@@ -88,7 +88,7 @@ export default deployScript(
       // Set deployer ETH balance
       await env.network.provider.request({
         method: "hardhat_setBalance",
-        params: [deployer, `0x${parseEther("100000000000000000000").toString(16)}`],
+        params: [deployer, `0x${parseEther("100000000000000000000").toString(16)}`] as never,
       });
 
       // The deployer is going to provide liquidity to the DEX so that we can swap tokens

--- a/extension/packages/hardhat/scripts/deployments.ts
+++ b/extension/packages/hardhat/scripts/deployments.ts
@@ -1,0 +1,15 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+
+// Returns a reader that resolves a deployed contract's address from its
+// deployment JSON for the given network.
+export function createDeploymentReader(networkName: string) {
+  const deploymentsDir = path.join(scriptsDir, "..", "deployments", networkName);
+  return (name: string): string => {
+    const filePath = path.join(deploymentsDir, `${name}.json`);
+    return JSON.parse(fs.readFileSync(filePath, "utf8")).address;
+  };
+}

--- a/extension/packages/hardhat/scripts/fetchPriceFromUniswap.ts
+++ b/extension/packages/hardhat/scripts/fetchPriceFromUniswap.ts
@@ -1,43 +1,78 @@
-import { ethers } from "hardhat";
 import * as dotenv from "dotenv";
 dotenv.config();
 
-import { config } from "hardhat";
+import { createPublicClient, http, zeroAddress } from "viem";
+import { mainnet } from "viem/chains";
 
 const UNISWAP_V2_PAIR_ABI = [
-  "function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)",
-  "function token0() external view returns (address)",
-  "function token1() external view returns (address)",
-];
+  {
+    inputs: [],
+    name: "getReserves",
+    outputs: [
+      { internalType: "uint112", name: "reserve0", type: "uint112" },
+      { internalType: "uint112", name: "reserve1", type: "uint112" },
+      { internalType: "uint32", name: "blockTimestampLast", type: "uint32" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "token0",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "token1",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
 
-const DAI_ADDRESS = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
-const WETH_ADDRESS = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
-const UNISWAP_V2_FACTORY = "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f";
-const mainnet = config.networks.mainnet;
-const MAINNET_RPC = "url" in mainnet ? mainnet.url : "";
+const UNISWAP_V2_FACTORY_ABI = [
+  {
+    inputs: [
+      { internalType: "address", name: "tokenA", type: "address" },
+      { internalType: "address", name: "tokenB", type: "address" },
+    ],
+    name: "getPair",
+    outputs: [{ internalType: "address", name: "pair", type: "address" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+const DAI_ADDRESS = "0x6B175474E89094C44Da98b954EedeAC495271d0F" as const;
+const WETH_ADDRESS = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" as const;
+const UNISWAP_V2_FACTORY = "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f" as const;
+
+const providerApiKey = process.env.ALCHEMY_API_KEY || "IZYEU2cWBgnFmgiTAgpWD";
+const MAINNET_RPC = `https://eth-mainnet.alchemyapi.io/v2/${providerApiKey}`;
 
 export const fetchPriceFromUniswap = async (): Promise<bigint> => {
   try {
-    const provider = new ethers.JsonRpcProvider(MAINNET_RPC);
-    const tokenAddress = WETH_ADDRESS; // Always use WETH for mainnet
+    const client = createPublicClient({ chain: mainnet, transport: http(MAINNET_RPC) });
+    const tokenAddress = WETH_ADDRESS;
 
-    // Get pair address from Uniswap V2 Factory
-    const factory = new ethers.Contract(
-      UNISWAP_V2_FACTORY,
-      ["function getPair(address tokenA, address tokenB) external view returns (address pair)"],
-      provider,
-    );
-
-    const pairAddress = await factory.getPair(tokenAddress, DAI_ADDRESS);
-    if (pairAddress === ethers.ZeroAddress) {
+    const pairAddress = (await client.readContract({
+      address: UNISWAP_V2_FACTORY,
+      abi: UNISWAP_V2_FACTORY_ABI,
+      functionName: "getPair",
+      args: [tokenAddress, DAI_ADDRESS],
+    })) as `0x${string}`;
+    if (pairAddress === zeroAddress) {
       throw new Error("No liquidity pair found");
     }
 
-    const pairContract = new ethers.Contract(pairAddress, UNISWAP_V2_PAIR_ABI, provider);
-    const [reserves, token0Address] = await Promise.all([pairContract.getReserves(), pairContract.token0()]);
+    const [reserves, token0Address] = await Promise.all([
+      client.readContract({ address: pairAddress, abi: UNISWAP_V2_PAIR_ABI, functionName: "getReserves" }),
+      client.readContract({ address: pairAddress, abi: UNISWAP_V2_PAIR_ABI, functionName: "token0" }),
+    ]);
 
-    // Determine which reserve is token and which is DAI
-    const isToken0 = token0Address.toLowerCase() === tokenAddress.toLowerCase();
+    const isToken0 = (token0Address as string).toLowerCase() === tokenAddress.toLowerCase();
     const tokenReserve = isToken0 ? reserves[0] : reserves[1];
     const daiReserve = isToken0 ? reserves[1] : reserves[0];
 

--- a/extension/packages/hardhat/scripts/fetchPriceFromUniswap.ts
+++ b/extension/packages/hardhat/scripts/fetchPriceFromUniswap.ts
@@ -57,12 +57,12 @@ export const fetchPriceFromUniswap = async (): Promise<bigint> => {
     const client = createPublicClient({ chain: mainnet, transport: http(MAINNET_RPC) });
     const tokenAddress = WETH_ADDRESS;
 
-    const pairAddress = (await client.readContract({
+    const pairAddress = await client.readContract({
       address: UNISWAP_V2_FACTORY,
       abi: UNISWAP_V2_FACTORY_ABI,
       functionName: "getPair",
       args: [tokenAddress, DAI_ADDRESS],
-    })) as `0x${string}`;
+    });
     if (pairAddress === zeroAddress) {
       throw new Error("No liquidity pair found");
     }
@@ -72,7 +72,7 @@ export const fetchPriceFromUniswap = async (): Promise<bigint> => {
       client.readContract({ address: pairAddress, abi: UNISWAP_V2_PAIR_ABI, functionName: "token0" }),
     ]);
 
-    const isToken0 = (token0Address as string).toLowerCase() === tokenAddress.toLowerCase();
+    const isToken0 = token0Address.toLowerCase() === tokenAddress.toLowerCase();
     const tokenReserve = isToken0 ? reserves[0] : reserves[1];
     const daiReserve = isToken0 ? reserves[1] : reserves[0];
 

--- a/extension/packages/hardhat/scripts/fetchPriceFromUniswap.ts
+++ b/extension/packages/hardhat/scripts/fetchPriceFromUniswap.ts
@@ -50,7 +50,7 @@ const WETH_ADDRESS = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" as const;
 const UNISWAP_V2_FACTORY = "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f" as const;
 
 const providerApiKey = process.env.ALCHEMY_API_KEY || "IZYEU2cWBgnFmgiTAgpWD";
-const MAINNET_RPC = `https://eth-mainnet.alchemyapi.io/v2/${providerApiKey}`;
+const MAINNET_RPC = `https://eth-mainnet.g.alchemy.com/v2/${providerApiKey}`;
 
 export const fetchPriceFromUniswap = async (): Promise<bigint> => {
   try {

--- a/extension/packages/hardhat/scripts/interestRateController.ts
+++ b/extension/packages/hardhat/scripts/interestRateController.ts
@@ -1,14 +1,5 @@
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { network } from "hardhat";
-import type {
-  DEX,
-  RateController,
-  MyUSDStaking,
-  MyUSDEngine,
-  Oracle,
-} from "../types/ethers-contracts/index.js";
+import type { DEX, RateController, MyUSDStaking, MyUSDEngine, Oracle } from "../types/ethers-contracts/index.js";
 import {
   DEX__factory,
   RateController__factory,
@@ -16,20 +7,11 @@ import {
   MyUSDEngine__factory,
   Oracle__factory,
 } from "../types/ethers-contracts/index.js";
+import { createDeploymentReader } from "./deployments.js";
 
 const { ethers, networkName } = await network.create();
 
-const deploymentsDir = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "..",
-  "deployments",
-  networkName,
-);
-
-function getDeployedAddress(name: string): string {
-  const filePath = path.join(deploymentsDir, `${name}.json`);
-  return JSON.parse(fs.readFileSync(filePath, "utf8")).address;
-}
+const getDeployedAddress = createDeploymentReader(networkName);
 
 // --- Config ---
 const TARGET_PRICE = 1;
@@ -164,7 +146,10 @@ function checkPegHit(direction: "UP" | "DOWN" | "FLAT"): boolean {
 async function main() {
   const [deployer] = await ethers.getSigners();
   const dex: DEX = DEX__factory.connect(getDeployedAddress("DEX"), deployer);
-  const rateController: RateController = RateController__factory.connect(getDeployedAddress("RateController"), deployer);
+  const rateController: RateController = RateController__factory.connect(
+    getDeployedAddress("RateController"),
+    deployer,
+  );
   const engine: MyUSDEngine = MyUSDEngine__factory.connect(getDeployedAddress("MyUSDEngine"), deployer);
   const staking: MyUSDStaking = MyUSDStaking__factory.connect(getDeployedAddress("MyUSDStaking"), deployer);
   const oracle: Oracle = Oracle__factory.connect(getDeployedAddress("Oracle"), deployer);

--- a/extension/packages/hardhat/scripts/interestRateController.ts
+++ b/extension/packages/hardhat/scripts/interestRateController.ts
@@ -1,7 +1,35 @@
-import hre from "hardhat";
-import { DEX, RateController, MyUSDStaking, MyUSDEngine, Oracle } from "../typechain-types";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { network } from "hardhat";
+import type {
+  DEX,
+  RateController,
+  MyUSDStaking,
+  MyUSDEngine,
+  Oracle,
+} from "../types/ethers-contracts/index.js";
+import {
+  DEX__factory,
+  RateController__factory,
+  MyUSDStaking__factory,
+  MyUSDEngine__factory,
+  Oracle__factory,
+} from "../types/ethers-contracts/index.js";
 
-const ethers = hre.ethers;
+const { ethers, networkName } = await network.create();
+
+const deploymentsDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "deployments",
+  networkName,
+);
+
+function getDeployedAddress(name: string): string {
+  const filePath = path.join(deploymentsDir, `${name}.json`);
+  return JSON.parse(fs.readFileSync(filePath, "utf8")).address;
+}
 
 // --- Config ---
 const TARGET_PRICE = 1;
@@ -135,11 +163,11 @@ function checkPegHit(direction: "UP" | "DOWN" | "FLAT"): boolean {
 
 async function main() {
   const [deployer] = await ethers.getSigners();
-  const dex = await ethers.getContract<DEX>("DEX", deployer);
-  const rateController = await ethers.getContract<RateController>("RateController", deployer);
-  const engine = await ethers.getContract<MyUSDEngine>("MyUSDEngine", deployer);
-  const staking = await ethers.getContract<MyUSDStaking>("MyUSDStaking", deployer);
-  const oracle = await ethers.getContract<Oracle>("Oracle", deployer);
+  const dex: DEX = DEX__factory.connect(getDeployedAddress("DEX"), deployer);
+  const rateController: RateController = RateController__factory.connect(getDeployedAddress("RateController"), deployer);
+  const engine: MyUSDEngine = MyUSDEngine__factory.connect(getDeployedAddress("MyUSDEngine"), deployer);
+  const staking: MyUSDStaking = MyUSDStaking__factory.connect(getDeployedAddress("MyUSDStaking"), deployer);
+  const oracle: Oracle = Oracle__factory.connect(getDeployedAddress("Oracle"), deployer);
   const ethPrice = await oracle.getETHUSDPrice();
 
   const startBorrowRate = await engine.borrowRate();
@@ -235,7 +263,7 @@ async function main() {
         const { newRate, newState } = getNextRate(borrowState, direction, isPriceStable);
         logChange(
           `Price ${currentPriceEth.toFixed(6)} ${currentPriceEth > TARGET_PRICE ? "above" : "below"} peg, ` +
-            `adjusting borrow rate to ${newRate}bps [${newState.searchBounds.low}, ${newState.searchBounds.high}]`,
+          `adjusting borrow rate to ${newRate}bps [${newState.searchBounds.low}, ${newState.searchBounds.high}]`,
         );
         await rateController.setBorrowRate(newRate);
         Object.assign(borrowState, newState);
@@ -253,7 +281,7 @@ async function main() {
           const boundedRate = Math.min(Math.max(newRate, SAVINGS_RATE_MIN), maximumRate);
           logChange(
             `Price ${currentPriceEth.toFixed(6)} ${currentPriceEth > TARGET_PRICE ? "above" : "below"} peg, ` +
-              `adjusting savings rate to ${boundedRate}bps [${newState.searchBounds.low}, ${maximumRate}]`,
+            `adjusting savings rate to ${boundedRate}bps [${newState.searchBounds.low}, ${maximumRate}]`,
           );
           await rateController.setSavingsRate(boundedRate);
           Object.assign(savingsState, newState);

--- a/extension/packages/hardhat/scripts/marketSimulator.ts
+++ b/extension/packages/hardhat/scripts/marketSimulator.ts
@@ -1,7 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { HDNodeWallet } from "ethers";
 import { network } from "hardhat";
 import type { DEX, MyUSDEngine, MyUSD, MyUSDStaking, Oracle } from "../types/ethers-contracts/index.js";
@@ -14,20 +11,11 @@ import {
 } from "../types/ethers-contracts/index.js";
 import blessed from "blessed";
 import contrib from "blessed-contrib";
+import { createDeploymentReader } from "./deployments.js";
 
 const { ethers, networkName } = await network.create();
 
-const deploymentsDir = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "..",
-  "deployments",
-  networkName,
-);
-
-function getDeployedAddress(name: string): string {
-  const filePath = path.join(deploymentsDir, `${name}.json`);
-  return JSON.parse(fs.readFileSync(filePath, "utf8")).address;
-}
+const getDeployedAddress = createDeploymentReader(networkName);
 
 // Account types and preferences
 interface BorrowerProfile {

--- a/extension/packages/hardhat/scripts/marketSimulator.ts
+++ b/extension/packages/hardhat/scripts/marketSimulator.ts
@@ -1,10 +1,33 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { HDNodeWallet } from "ethers";
-import hre from "hardhat";
-import { DEX, MyUSDEngine, MyUSD, MyUSDStaking, Oracle } from "../typechain-types";
-import * as blessed from "blessed";
-import * as contrib from "blessed-contrib";
-const ethers = hre.ethers;
+import { network } from "hardhat";
+import type { DEX, MyUSDEngine, MyUSD, MyUSDStaking, Oracle } from "../types/ethers-contracts/index.js";
+import {
+  DEX__factory,
+  MyUSDEngine__factory,
+  MyUSD__factory,
+  MyUSDStaking__factory,
+  Oracle__factory,
+} from "../types/ethers-contracts/index.js";
+import blessed from "blessed";
+import contrib from "blessed-contrib";
+
+const { ethers, networkName } = await network.create();
+
+const deploymentsDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "deployments",
+  networkName,
+);
+
+function getDeployedAddress(name: string): string {
+  const filePath = path.join(deploymentsDir, `${name}.json`);
+  return JSON.parse(fs.readFileSync(filePath, "utf8")).address;
+}
 
 // Account types and preferences
 interface BorrowerProfile {
@@ -171,7 +194,7 @@ function getBorrowerStatus(
   const rateFactor =
     1 -
     (Math.min(currentBorrowRate, borrower.maxAcceptableRate) / borrower.maxAcceptableRate) *
-      (borrower.rateSensitivity / 100);
+    (borrower.rateSensitivity / 100);
 
   const borrowingWillingness = (borrower.debtTolerance / 100) * rateFactor;
 
@@ -273,9 +296,9 @@ async function updateUI(
     try {
       systemInfoBox.setContent(
         `MyUSD Price: {yellow-fg}${myUSDPriceInUSD.toFixed(6)}{/yellow-fg}  |  ` +
-          `ETH Price: {cyan-fg}${ethToMyUSDPriceNum.toFixed(1)} MyUSD{/cyan-fg} | ` +
-          `Savings Rate: {cyan-fg}${savingsRate > 0 ? savingsRate / 100 : 0}% {/cyan-fg}  |  ` +
-          `Borrow Rate: {magenta-fg}${borrowRate > 0 ? borrowRate / 100 : 0}% {/magenta-fg}`,
+        `ETH Price: {cyan-fg}${ethToMyUSDPriceNum.toFixed(1)} MyUSD{/cyan-fg} | ` +
+        `Savings Rate: {cyan-fg}${savingsRate > 0 ? savingsRate / 100 : 0}% {/cyan-fg}  |  ` +
+        `Borrow Rate: {magenta-fg}${borrowRate > 0 ? borrowRate / 100 : 0}% {/magenta-fg}`,
       );
     } catch (error: any) {
       console.log(`Error updating system info: ${error}`);
@@ -451,7 +474,7 @@ async function simulateBorrowing(
 
           logActivity(
             `Borrower ${borrower.wallet.address.slice(0, 6)}... repaid ${ethers.formatEther(amountToBurn).slice(0, 6)} MyUSD ` +
-              `(keeping ${ethers.formatEther(amountToKeep).slice(0, 6)} MyUSD)`,
+            `(keeping ${ethers.formatEther(amountToKeep).slice(0, 6)} MyUSD)`,
           );
         } catch (error: any) {
           logActivity(`Failed to repay debt for ${borrower.wallet.address.slice(0, 6)}...`);
@@ -470,7 +493,7 @@ async function simulateBorrowing(
 
             logActivity(
               `Borrower ${borrower.wallet.address.slice(0, 6)}... swapped ${ethers.formatEther(safeEthToSwap).slice(0, 6)} ETH for MyUSD ` +
-                `to repay debt (rate: ${currentBorrowRate} > ${borrower.maxAcceptableRate})`,
+              `to repay debt (rate: ${currentBorrowRate} > ${borrower.maxAcceptableRate})`,
             );
             continue;
           } catch (error: any) {
@@ -486,7 +509,7 @@ async function simulateBorrowing(
       const rateFactor =
         1 -
         (Math.min(currentBorrowRate, borrower.maxAcceptableRate) / borrower.maxAcceptableRate) *
-          (borrower.rateSensitivity / 100);
+        (borrower.rateSensitivity / 100);
 
       // Higher tolerance + lower rate sensitivity = more borrowing
       const borrowingWillingness = (borrower.debtTolerance / 100) * rateFactor;
@@ -583,7 +606,7 @@ async function executeBorrowing(
 
     logActivity(
       `Borrower ${borrower.wallet.address.slice(0, 6)}... leveraged borrowed ${ethers.formatEther(borrowAmount).slice(0, 6)} MyUSD ` +
-        `(rate: ${currentBorrowRate} bps, willingness: ${(borrowingWillingness * 100).toFixed(1)}%)`,
+      `(rate: ${currentBorrowRate} bps, willingness: ${(borrowingWillingness * 100).toFixed(1)}%)`,
     );
   } catch (error: any) {
     logActivity(`Leveraged borrowing failed for ${borrower.wallet.address.slice(0, 6)}... Error: ${error}`);
@@ -617,7 +640,7 @@ async function simulateStaking(
 
           logActivity(
             `Staker ${staker.wallet.address.slice(0, 6)}... unstaked ALL shares ` +
-              `(rate: ${currentSavingsRate} bps < min rate: ${staker.minAcceptableRate} bps)`,
+            `(rate: ${currentSavingsRate} bps < min rate: ${staker.minAcceptableRate} bps)`,
           );
         }
       } catch (error: any) {
@@ -637,7 +660,7 @@ async function simulateStaking(
 
             logActivity(
               `Staker ${staker.wallet.address.slice(0, 6)}... sold ALL MyUSD (${ethers.formatEther(sellableBalance).slice(0, 6)}) for ETH ` +
-                `(rate too low: ${currentSavingsRate} < ${staker.minAcceptableRate} bps)`,
+              `(rate too low: ${currentSavingsRate} < ${staker.minAcceptableRate} bps)`,
             );
           }
         } catch (error: any) {
@@ -685,7 +708,7 @@ async function simulateStaking(
           await stakingWithStaker.stake(amountToStake);
           logActivity(
             `Staker ${staker.wallet.address.slice(0, 6)}... staked ${ethers.formatEther(amountToStake).slice(0, 6)} MyUSD ` +
-              `(rate: ${currentSavingsRate} bps, willingness: ${(stakingWillingness * 100).toFixed(1)}%)`,
+            `(rate: ${currentSavingsRate} bps, willingness: ${(stakingWillingness * 100).toFixed(1)}%)`,
           );
         } catch (error: any) {
           logActivity(`Failed to stake for ${staker.wallet.address.slice(0, 6)}...`);
@@ -754,12 +777,12 @@ async function main() {
     logActivity("Initializing simulator...");
 
     const [deployer] = await ethers.getSigners();
-    const dex = await ethers.getContract<DEX>("DEX", deployer);
-    const oracle = await ethers.getContract<Oracle>("Oracle", deployer);
+    const dex: DEX = DEX__factory.connect(getDeployedAddress("DEX"), deployer);
+    const oracle: Oracle = Oracle__factory.connect(getDeployedAddress("Oracle"), deployer);
     const ethPrice = await oracle.getETHUSDPrice();
-    const engine = await ethers.getContract<MyUSDEngine>("MyUSDEngine", deployer);
-    const myUSD = await ethers.getContract<MyUSD>("MyUSD", deployer);
-    const staking = await ethers.getContract<MyUSDStaking>("MyUSDStaking", deployer);
+    const engine: MyUSDEngine = MyUSDEngine__factory.connect(getDeployedAddress("MyUSDEngine"), deployer);
+    const myUSD: MyUSD = MyUSD__factory.connect(getDeployedAddress("MyUSD"), deployer);
+    const staking: MyUSDStaking = MyUSDStaking__factory.connect(getDeployedAddress("MyUSDStaking"), deployer);
 
     logActivity("Connected to deployed contracts");
     const accounts = await setupAccounts();

--- a/extension/packages/hardhat/test/MyUSDEngine.ts
+++ b/extension/packages/hardhat/test/MyUSDEngine.ts
@@ -2,13 +2,15 @@
 // This script executes when you run 'yarn test'
 //
 
-import { ethers } from "hardhat";
+import { network } from "hardhat";
 import { expect } from "chai";
-import { MyUSD, DEX, MyUSDEngine, Oracle, MyUSDStaking, RateController } from "../typechain-types";
-import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
-import { fetchPriceFromUniswap } from "../scripts/fetchPriceFromUniswap";
+import type { MyUSD, DEX, MyUSDEngine, Oracle, MyUSDStaking, RateController } from "../types/ethers-contracts/index.js";
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types";
+import { fetchPriceFromUniswap } from "../scripts/fetchPriceFromUniswap.js";
 
 describe("🚩 Stablecoin Challenge 🤓", function () {
+  let ethers: Awaited<ReturnType<typeof network.create>>["ethers"];
+
   const contractAddress = process.env.CONTRACT_ADDRESS;
   let myUSDToken: MyUSD;
   let dex: DEX;
@@ -16,12 +18,18 @@ describe("🚩 Stablecoin Challenge 🤓", function () {
   let oracle: Oracle;
   let staking: MyUSDStaking;
   let rateController: RateController;
-  let owner: SignerWithAddress;
-  let user1: SignerWithAddress;
-  let user2: SignerWithAddress;
+  let owner: HardhatEthersSigner;
+  let user1: HardhatEthersSigner;
+  let user2: HardhatEthersSigner;
 
-  const collateralAmount = ethers.parseEther("10");
-  const borrowAmount = ethers.parseEther("5000");
+  let collateralAmount: bigint;
+  let borrowAmount: bigint;
+
+  before(async function () {
+    ({ ethers } = await network.create());
+    collateralAmount = ethers.parseEther("10");
+    borrowAmount = ethers.parseEther("5000");
+  });
 
   beforeEach(async function () {
     await ethers.provider.send("hardhat_reset", []);
@@ -51,29 +59,29 @@ describe("🚩 Stablecoin Challenge 🤓", function () {
 
     // Deploy RateController first
     const RateControllerFactory = await ethers.getContractFactory("RateController");
-    rateController = await RateControllerFactory.deploy(futureEngineAddress, futureStakingAddress);
+    rateController = (await RateControllerFactory.deploy(futureEngineAddress, futureStakingAddress)) as unknown as RateController;
 
     // Deploy MyUSD with future addresses
     const MyUSDFactory = await ethers.getContractFactory("MyUSD");
-    myUSDToken = await MyUSDFactory.deploy(futureEngineAddress, futureStakingAddress);
+    myUSDToken = (await MyUSDFactory.deploy(futureEngineAddress, futureStakingAddress)) as unknown as MyUSD;
 
     // Deploy DEX
     const DEXFactory = await ethers.getContractFactory("DEX");
-    dex = await DEXFactory.deploy(await myUSDToken.getAddress());
+    dex = (await DEXFactory.deploy(await myUSDToken.getAddress())) as unknown as DEX;
 
     const ethPrice = await fetchPriceFromUniswap();
 
     // Deploy Oracle
     const OracleFactory = await ethers.getContractFactory("Oracle");
-    oracle = await OracleFactory.deploy(await dex.getAddress(), ethPrice);
+    oracle = (await OracleFactory.deploy(await dex.getAddress(), ethPrice)) as unknown as Oracle;
 
     // Deploy MyUSDStaking
     const MyUSDStakingFactory = await ethers.getContractFactory("MyUSDStaking");
-    staking = await MyUSDStakingFactory.deploy(
+    staking = (await MyUSDStakingFactory.deploy(
       await myUSDToken.getAddress(),
       futureEngineAddress,
       await rateController.getAddress(),
-    );
+    )) as unknown as MyUSDStaking;
 
     // Finally deploy the MyUSDEngine at the predicted address
     const MyUSDEngineFactory = await ethers.getContractFactory(contractArtifact);
@@ -82,7 +90,7 @@ describe("🚩 Stablecoin Challenge 🤓", function () {
       await myUSDToken.getAddress(),
       await staking.getAddress(),
       await rateController.getAddress(),
-    )) as MyUSDEngine;
+    )) as unknown as MyUSDEngine;
 
     // Verify addresses match predictions
     expect(await myUSDEngine.getAddress()).to.equal(futureEngineAddress);

--- a/extension/packages/hardhat/test/MyUSDEngine.ts
+++ b/extension/packages/hardhat/test/MyUSDEngine.ts
@@ -25,14 +25,10 @@ describe("🚩 Stablecoin Challenge 🤓", function () {
   let collateralAmount: bigint;
   let borrowAmount: bigint;
 
-  before(async function () {
+  beforeEach(async function () {
     ({ ethers } = await network.create());
     collateralAmount = ethers.parseEther("10");
     borrowAmount = ethers.parseEther("5000");
-  });
-
-  beforeEach(async function () {
-    await ethers.provider.send("hardhat_reset", []);
     [owner, user1, user2] = await ethers.getSigners();
 
     // For SRE Auto-grader - use the the downloaded contract instead of default contract
@@ -59,7 +55,10 @@ describe("🚩 Stablecoin Challenge 🤓", function () {
 
     // Deploy RateController first
     const RateControllerFactory = await ethers.getContractFactory("RateController");
-    rateController = (await RateControllerFactory.deploy(futureEngineAddress, futureStakingAddress)) as unknown as RateController;
+    rateController = (await RateControllerFactory.deploy(
+      futureEngineAddress,
+      futureStakingAddress,
+    )) as unknown as RateController;
 
     // Deploy MyUSD with future addresses
     const MyUSDFactory = await ethers.getContractFactory("MyUSD");
@@ -434,8 +433,8 @@ describe("🚩 Stablecoin Challenge 🤓", function () {
     });
 
     it("Should prevent setting borrow rate below savings rate", async function () {
-      await rateController.setSavingsRate(0);
-      expect(await rateController.setBorrowRate(300)).to.be.revertedWithCustomError(
+      await rateController.setSavingsRate(350);
+      await expect(rateController.setBorrowRate(300)).to.be.revertedWithCustomError(
         myUSDEngine,
         "Engine__InvalidBorrowRate",
       );

--- a/extension/packages/nextjs/app/_components/Modals/TokenSwapModal.tsx
+++ b/extension/packages/nextjs/app/_components/Modals/TokenSwapModal.tsx
@@ -124,7 +124,7 @@ export const TokenSwapModal = ({ tokenBalance, connectedAddress, ETHprice, modal
                   <span className="text-sm pl-3">
                     {tokenBalance} {tokenName}
                   </span>
-                  <Balance address={connectedAddress as Address} className="min-h-0 h-auto" />
+                  <Balance address={connectedAddress as Address} style={{ minHeight: 0, height: "auto" }} />
                 </div>
               </div>
             </div>

--- a/extension/packages/nextjs/next.config.ts.args.mjs
+++ b/extension/packages/nextjs/next.config.ts.args.mjs
@@ -2,7 +2,4 @@ export const configOverrides = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
 };


### PR DESCRIPTION
## Summary
- Migrate deploy to `rocketh`'s `deployScript`. Use `viem`'s `parseEther` / `getContractAddress` and `env.network.provider.request` for `eth_getTransactionCount` / `hardhat_setBalance`.
- Use `env.execute` for `addCollateral` / `mintMyUSD` / `approve` / `init` / `transferOwnership`; `env.read` for `balanceOf`.
- Replace `hre.network.name === "localhost"` check with `env.name === "default" || env.name === "localhost"`.
- Rewrite `fetchPriceFromUniswap.ts` to use a viem public client (drops the `import { ethers, config } from "hardhat"` that no longer works at module scope in HH v3).
- Migrate test: `network.create()` in `before`, `HardhatEthersSigner` import path `/signers` → `/types`, cast deploys with `as unknown as`.
- Remove `eslint.ignoreDuringBuilds` from `next.config.ts.args.mjs`.

## Test plan
- [ ] `yarn deploy` deploys all 6 contracts and seeds DEX liquidity
- [ ] `yarn hardhat:test` passes