### PR TITLE
feat: token-vendor migration to hh v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Before you begin, you need to install the following tools:
 Then download the challenge to your computer and install dependencies by running:
 
 ```sh
-npx create-eth@2.0.18 -e challenge-token-vendor challenge-token-vendor
+npx create-eth@2.0.20 -e challenge-token-vendor challenge-token-vendor
 ```
 
 > When prompted, choose your preferred Solidity framework: **Hardhat** or **Foundry**.

--- a/extension/packages/hardhat/deploy/00_deploy_your_token.ts
+++ b/extension/packages/hardhat/deploy/00_deploy_your_token.ts
@@ -1,43 +1,28 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-// import { Contract } from "ethers";
+import { artifacts, deployScript } from "../rocketh/deploy.js";
 
 /**
- * Deploys a contract named "YourToken" using the deployer account and
- * constructor arguments set to the deployer address
+ * Deploys a contract named "YourToken" using the deployer account.
  *
- * @param hre HardhatRuntimeEnvironment object.
+ * On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+ *
+ * When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
+ * should have sufficient balance to pay for the gas fees for contract creation.
+ *
+ * You can generate a random account with `yarn generate` which will fill DEPLOYER_PRIVATE_KEY_ENCRYPTED
+ * in the .env file (used in hardhat.config.ts).
+ * Run `yarn account` to check the deployer balance on every network.
  */
-const deployYourToken: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  /*
-    On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+export default deployScript(
+  async ({ deploy, namedAccounts }) => {
+    const { deployer } = namedAccounts;
 
-    When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
-    should have sufficient balance to pay for the gas fees for contract creation.
-
-    You can generate a random account with `yarn generate` which will fill DEPLOYER_PRIVATE_KEY
-    with a random private key in the .env file (then used on hardhat.config.ts)
-    You can run the `yarn account` command to check your balance in every network.
-  */
-  const { deployer } = await hre.getNamedAccounts();
-  const { deploy } = hre.deployments;
-
-  await deploy("YourToken", {
-    from: deployer,
-    // Contract constructor arguments
-    args: [],
-    log: true,
-    // autoMine: can be passed to the deploy function to make the deployment process faster on local networks by
-    // automatically mining the contract deployment transaction. There is no effect on live networks.
-    autoMine: true,
-  });
-
-  // Get the deployed contract
-  // const yourToken = await hre.ethers.getContract<Contract>("YourToken", deployer);
-};
-
-export default deployYourToken;
-
-// Tags are useful if you have multiple deploy files and only want to run one of them.
-// e.g. yarn deploy --tags YourToken
-deployYourToken.tags = ["YourToken"];
+    await deploy("YourToken", {
+      account: deployer,
+      artifact: artifacts.YourToken,
+      args: [],
+    });
+  },
+  // Tags are useful if you have multiple deploy files and only want to run one of them.
+  // e.g. yarn deploy --tags YourToken
+  { tags: ["YourToken"] },
+);

--- a/extension/packages/hardhat/deploy/01_deploy_vendor.ts
+++ b/extension/packages/hardhat/deploy/01_deploy_vendor.ts
@@ -1,75 +1,74 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { Contract } from "ethers";
+import { artifacts, deployScript } from "../rocketh/deploy.js";
+import { parseEther } from "viem";
 
 /**
- * Deploys a contract named "Vendor" using the deployer account and
- * constructor arguments set to the deployer address
+ * Deploys a contract named "Vendor" using the deployer account.
  *
- * @param hre HardhatRuntimeEnvironment object.
+ * On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+ *
+ * When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
+ * should have sufficient balance to pay for the gas fees for contract creation.
+ *
+ * You can generate a random account with `yarn generate` which will fill DEPLOYER_PRIVATE_KEY_ENCRYPTED
+ * in the .env file (used in hardhat.config.ts).
+ * Run `yarn account` to check the deployer balance on every network.
  */
-const deployVendor: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  /*
-    On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+export default deployScript(
+  async env => {
+    const { deployer } = env.namedAccounts;
+    const yourToken = env.get<typeof artifacts.YourToken.abi>("YourToken");
 
-    When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
-    should have sufficient balance to pay for the gas fees for contract creation.
+    /**
+     * Student TODO:
+     * - Put the address you're using in the frontend here (leave "" to default to the deployer)
+     */
+    const FRONTEND_ADDRESS = "";
 
-    You can generate a random account with `yarn generate` which will fill DEPLOYER_PRIVATE_KEY
-    with a random private key in the .env file (then used on hardhat.config.ts)
-    You can run the `yarn account` command to check your balance in every network.
-  */
-  const { deployer } = await hre.getNamedAccounts();
-  const { deploy } = hre.deployments;
-  const yourToken = await hre.ethers.getContract<Contract>("YourToken", deployer);
+    /**
+     * Mode switch:
+     * - If true: deploy Vendor and seed it with the token balance
+     * - If false: send tokens to your frontend address (or deployer if unset)
+     */
+    const SEND_TOKENS_TO_VENDOR = false; // Don't switch until Checkpoint 2!
 
-  /**
-   * Student TODO:
-   * - Put the address you’re using in the frontend here (leave "" to default to the deployer)
-   */
-  const FRONTEND_ADDRESS: string = "";
+    const recipientAddress =
+      FRONTEND_ADDRESS && FRONTEND_ADDRESS.trim().length > 0 ? (FRONTEND_ADDRESS as `0x${string}`) : deployer;
 
-  /**
-   * Mode switch:
-   * - If true: deploy Vendor and seed it with the token balance
-   * - If false: send tokens to your frontend address (or deployer if unset)
-   */
-  const SEND_TOKENS_TO_VENDOR = false; // Don't switch until Checkpoint 2!
+    if (!SEND_TOKENS_TO_VENDOR) {
+      // Send the entire initial supply to the wallet you use in the UI (useful when deployer != UI wallet).
+      // If FRONTEND_ADDRESS is "", this defaults to the deployer (no-op transfer).
+      if (recipientAddress !== deployer) {
+        await env.execute(yourToken, {
+          functionName: "transfer",
+          args: [recipientAddress, parseEther("1000")],
+          account: deployer,
+        });
+      }
+      return;
+    } else {
+      // Deploy Vendor
+      const vendor = await env.deploy("Vendor", {
+        account: deployer,
+        artifact: artifacts.Vendor,
+        args: [yourToken.address],
+      });
 
-  const recipientAddress = FRONTEND_ADDRESS && FRONTEND_ADDRESS.trim().length > 0 ? FRONTEND_ADDRESS : deployer;
+      // Transfer tokens to Vendor (seed inventory)
+      await env.execute(yourToken, {
+        functionName: "transfer",
+        args: [vendor.address, parseEther("1000")],
+        account: deployer,
+      });
 
-  if (!SEND_TOKENS_TO_VENDOR) {
-    // Send the entire initial supply to the wallet you use in the UI (useful when deployer != UI wallet).
-    // If FRONTEND_ADDRESS is "", this defaults to the deployer (no-op transfer).
-    if (recipientAddress != deployer) {
-      await yourToken.transfer(recipientAddress, hre.ethers.parseEther("1000"));
+      // Make the UI wallet the owner (for withdraw(), etc). Defaults to deployer if unset.
+      await env.execute(vendor, {
+        functionName: "transferOwnership",
+        args: [recipientAddress],
+        account: deployer,
+      });
     }
-    return;
-  } else {
-    // Deploy Vendor
-    const yourTokenAddress = await yourToken.getAddress();
-    await deploy("Vendor", {
-      from: deployer,
-      // Contract constructor arguments
-      args: [yourTokenAddress],
-      log: true,
-      // autoMine: can be passed to the deploy function to make the deployment process faster on local networks by
-      // automatically mining the contract deployment transaction. There is no effect on live networks.
-      autoMine: true,
-    });
-    const vendor = await hre.ethers.getContract<Contract>("Vendor", deployer);
-    const vendorAddress = await vendor.getAddress();
-
-    // Transfer tokens to Vendor (seed inventory)
-    await yourToken.transfer(vendorAddress, hre.ethers.parseEther("1000"));
-
-    // Make the UI wallet the owner (for withdraw(), etc). Defaults to deployer if unset.
-    await vendor.transferOwnership(recipientAddress);
-  }
-};
-
-export default deployVendor;
-
-// Tags are useful if you have multiple deploy files and only want to run one of them.
-// e.g. yarn deploy --tags Vendor
-deployVendor.tags = ["Vendor"];
+  },
+  // Tags are useful if you have multiple deploy files and only want to run one of them.
+  // e.g. yarn deploy --tags Vendor
+  { tags: ["Vendor"] },
+);

--- a/extension/packages/hardhat/test/Vendor.ts
+++ b/extension/packages/hardhat/test/Vendor.ts
@@ -66,7 +66,7 @@ describe("🚩 Challenge: 🏵 Token Vendor 🤖", function () {
       const { deployer, user, yourToken } = await deployYourTokenFixture();
 
       const amount = ethers.parseEther("10");
-      await expect(yourToken.transfer(user.address, amount)).to.not.be.reverted;
+      await expect(yourToken.transfer(user.address, amount)).to.not.be.revert(ethers);
 
       expect(await yourToken.balanceOf(user.address)).to.equal(amount);
       expect(await yourToken.balanceOf(deployer.address)).to.equal(INITIAL_SUPPLY - amount);
@@ -130,7 +130,7 @@ describe("🚩 Challenge: 🏵 Token Vendor 🤖", function () {
       const { user, yourTokenAddress } = await deployYourTokenFixture();
       const { vendor } = await deployVendorFixture(yourTokenAddress);
 
-      await expect(vendor.connect(user).withdraw()).to.be.reverted;
+      await expect(vendor.connect(user).withdraw()).to.be.revert(ethers);
     });
 
     it("Checkpoint3: withdraw sends all ETH in Vendor to the owner", async function () {

--- a/extension/packages/hardhat/test/Vendor.ts
+++ b/extension/packages/hardhat/test/Vendor.ts
@@ -2,12 +2,9 @@
 // this script executes when you run 'yarn harhat:test'
 //
 
-import hre from "hardhat";
+import { network } from "hardhat";
 import { expect } from "chai";
-import { impersonateAccount, stopImpersonatingAccount } from "@nomicfoundation/hardhat-network-helpers";
-import { Vendor, YourToken } from "../typechain-types";
-
-const { ethers } = hre;
+import type { Vendor, YourToken } from "../types/ethers-contracts/index.js";
 
 describe("🚩 Challenge: 🏵 Token Vendor 🤖", function () {
   // NOTE: The README expects tests grouped by checkpoint so you can run:
@@ -15,6 +12,9 @@ describe("🚩 Challenge: 🏵 Token Vendor 🤖", function () {
   //   yarn test --grep "Checkpoint2"
   //   yarn test --grep "Checkpoint3"
   //   yarn test --grep "Checkpoint4"
+
+  let ethers: Awaited<ReturnType<typeof network.create>>["ethers"];
+  let networkHelpers: Awaited<ReturnType<typeof network.create>>["networkHelpers"];
 
   const contractAddress = process.env.CONTRACT_ADDRESS;
 
@@ -29,19 +29,24 @@ describe("🚩 Challenge: 🏵 Token Vendor 🤖", function () {
   };
 
   const TOKENS_PER_ETH = 100n;
-  const INITIAL_SUPPLY = ethers.parseEther("1000");
+  let INITIAL_SUPPLY: bigint;
+
+  before(async function () {
+    ({ ethers, networkHelpers } = await network.create());
+    INITIAL_SUPPLY = ethers.parseEther("1000");
+  });
 
   async function deployYourTokenFixture() {
     const [deployer, user] = await ethers.getSigners();
     const YourTokenFactory = await ethers.getContractFactory(getYourTokenArtifact());
-    const yourToken = (await YourTokenFactory.deploy()) as YourToken;
+    const yourToken = (await YourTokenFactory.deploy()) as unknown as YourToken;
     await yourToken.waitForDeployment();
     return { deployer, user, yourToken, yourTokenAddress: await yourToken.getAddress() };
   }
 
   async function deployVendorFixture(yourTokenAddress: string) {
     const VendorFactory = await ethers.getContractFactory(getVendorArtifact());
-    const vendor = (await VendorFactory.deploy(yourTokenAddress)) as Vendor;
+    const vendor = (await VendorFactory.deploy(yourTokenAddress)) as unknown as Vendor;
     await vendor.waitForDeployment();
     return { vendor, vendorAddress: await vendor.getAddress() };
   }
@@ -170,7 +175,7 @@ describe("🚩 Challenge: 🏵 Token Vendor 🤖", function () {
 
       const vendorEthBefore = await ethers.provider.getBalance(vendorAddress);
 
-      await impersonateAccount(vendorAddress);
+      await networkHelpers.impersonateAccount(vendorAddress);
       try {
         const vendorAsOwner = await ethers.getSigner(vendorAddress);
         // Use a simulation call (no gas is paid from vendorAddress), otherwise the tx gas would
@@ -179,7 +184,7 @@ describe("🚩 Challenge: 🏵 Token Vendor 🤖", function () {
           .to.be.revertedWithCustomError(vendor, "EthTransferFailed")
           .withArgs(vendorAddress, vendorEthBefore);
       } finally {
-        await stopImpersonatingAccount(vendorAddress);
+        await networkHelpers.stopImpersonatingAccount(vendorAddress);
       }
     });
   });

--- a/extension/packages/nextjs/next.config.ts.args.mjs
+++ b/extension/packages/nextjs/next.config.ts.args.mjs
@@ -2,7 +2,4 @@ export const configOverrides = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
 };


### PR DESCRIPTION
## Summary
- Migrate both deploys to `rocketh`'s `deployScript`. `01_deploy_vendor.ts` uses `env.get("YourToken")` to look up the prior deployment.
- Use `env.execute` for `transfer` / `transferOwnership` calls; replace `hre.ethers.parseEther` with `viem`'s `parseEther`.
- Migrate test: `network.create()` in `before` (also destructures `networkHelpers`); replace `impersonateAccount` / `stopImpersonatingAccount` from `@nomicfoundation/hardhat-network-helpers` with `networkHelpers.impersonateAccount` / `networkHelpers.stopImpersonatingAccount`.
- Drop the `import hre from "hardhat"` + `const { ethers } = hre` pattern.
- Cast deploys with `as unknown as`.
- Remove `eslint.ignoreDuringBuilds` from `next.config.ts.args.mjs`.

## Test plan
- [ ] `yarn deploy` deploys `YourToken` (and `Vendor` when `SEND_TOKENS_TO_VENDOR=true`)
- [ ] `yarn hardhat:test` passes (including the EthTransferFailed impersonation test)