### PR TITLE
feat: dice-game migration to hh v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Before you begin, you need to install the following tools:
 Then download the challenge to your computer and install dependencies by running:
 
 ```sh
-npx create-eth@2.0.18 -e challenge-dice-game challenge-dice-game
+npx create-eth@2.0.20 -e challenge-dice-game challenge-dice-game
 ```
 
 > When prompted, choose your preferred Solidity framework: **Hardhat** or **Foundry**.

--- a/extension/packages/hardhat/deploy/00_deploy_diceGame.ts
+++ b/extension/packages/hardhat/deploy/00_deploy_diceGame.ts
@@ -1,29 +1,24 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { ethers } from "hardhat/";
-import { DiceGame } from "../typechain-types/";
+import { artifacts, deployScript } from "../rocketh/deploy.js";
+import { parseEther, formatEther } from "viem";
 
-const deployDiceGame: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployer } = await hre.getNamedAccounts();
-  const { deploy } = hre.deployments;
+export default deployScript(
+  async env => {
+    const { deployer } = env.namedAccounts;
 
-  await deploy("DiceGame", {
-    from: deployer,
-    value: String(ethers.parseEther("0.05")),
-    log: true,
-  });
+    const diceGame = await env.deploy("DiceGame", {
+      account: deployer,
+      artifact: artifacts.DiceGame,
+      args: [],
+      value: parseEther("0.05"),
+    });
 
-  // Simple example on how get the deployed dice game contract
-  const diceGame: DiceGame = await ethers.getContract("DiceGame");
+    console.log("Deployed Dice Game Contract Address", diceGame.address);
 
-  const diceGameAddress = await diceGame.getAddress();
-
-  console.log("Deployed Dice Game Contract Address", diceGameAddress);
-
-  const balance = await ethers.provider.getBalance(diceGameAddress);
-  console.log("Deployed Dice Game Contract Balance", ethers.formatEther(balance.toString()));
-};
-
-export default deployDiceGame;
-
-deployDiceGame.tags = ["DiceGame"];
+    const balanceHex = (await env.network.provider.request({
+      method: "eth_getBalance",
+      params: [diceGame.address, "latest"],
+    })) as `0x${string}`;
+    console.log("Deployed Dice Game Contract Balance", formatEther(BigInt(balanceHex)));
+  },
+  { tags: ["DiceGame"] },
+);

--- a/extension/packages/hardhat/deploy/00_deploy_diceGame.ts
+++ b/extension/packages/hardhat/deploy/00_deploy_diceGame.ts
@@ -9,6 +9,12 @@ export default deployScript(
       account: deployer,
       artifact: artifacts.DiceGame,
       args: [],
+    });
+
+    // env.deploy ignores `value`; fund the contract separately (DiceGame has receive())
+    await env.tx({
+      account: deployer,
+      to: diceGame.address,
       value: parseEther("0.05"),
     });
 

--- a/extension/packages/hardhat/deploy/01_deploy_riggedRoll.ts
+++ b/extension/packages/hardhat/deploy/01_deploy_riggedRoll.ts
@@ -1,33 +1,28 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { ethers } from "hardhat/";
-import { DiceGame, RiggedRoll } from "../typechain-types";
+import { deployScript } from "../rocketh/deploy.js";
 
-const deployRiggedRoll: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployer } = await hre.getNamedAccounts();
-  const { deploy } = hre.deployments;
+export default deployScript(
+  async env => {
+    const diceGame = env.get("DiceGame");
+    const diceGameAddress = diceGame.address;
 
-  const diceGame: DiceGame = await ethers.getContract("DiceGame");
-  const diceGameAddress = await diceGame.getAddress();
+    // Uncomment to deploy RiggedRoll contract
+    // const riggedRoll = await env.deploy("RiggedRoll", {
+    //   account: env.namedAccounts.deployer,
+    //   artifact: artifacts.RiggedRoll,
+    //   args: [diceGameAddress],
+    // });
 
-  // Uncomment to deploy RiggedRoll contract
-  // await deploy("RiggedRoll", {
-  //   from: deployer,
-  //   log: true,
-  //   args: [diceGameAddress],
-  //   autoMine: true,
-  // });
-
-  // const riggedRoll: RiggedRoll = await ethers.getContract("RiggedRoll", deployer);
-
-  // Please replace the text "Your Address" with your own address.
-  // try {
-  //   await riggedRoll.transferOwnership("Your Address");
-  // } catch (err) {
-  //   console.log(err);
-  // }
-};
-
-export default deployRiggedRoll;
-
-deployRiggedRoll.tags = ["RiggedRoll"];
+    // Please replace the text "Your Address" with your own address.
+    // try {
+    //   await env.execute(riggedRoll, {
+    //     functionName: "transferOwnership",
+    //     args: ["Your Address"],
+    //     account: env.namedAccounts.deployer,
+    //   });
+    // } catch (err) {
+    //   console.log(err);
+    // }
+    void diceGameAddress;
+  },
+  { tags: ["RiggedRoll"] },
+);

--- a/extension/packages/hardhat/test/RiggedRoll.ts
+++ b/extension/packages/hardhat/test/RiggedRoll.ts
@@ -1,24 +1,30 @@
-import hre from "hardhat";
+import { network } from "hardhat";
 import { expect } from "chai";
 // import { parseEther } from "ethers";
-import { DiceGame, RiggedRoll, RiggedRoll__factory } from "../typechain-types";
-import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
-
-const { ethers } = hre;
+import type { DiceGame, RiggedRoll, RiggedRoll__factory } from "../types/ethers-contracts/index.js";
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types";
 
 describe("🚩 Challenge: 🎲 Dice Game", function () {
+  let ethers: Awaited<ReturnType<typeof network.create>>["ethers"];
+  let provider: Awaited<ReturnType<typeof network.create>>["ethers"]["provider"];
+
   let diceGame: DiceGame;
   let riggedRoll: RiggedRoll;
   let deployer: HardhatEthersSigner;
-  const { provider } = ethers;
 
   const rollAmountString = "0.002";
-  const rollAmount = ethers.parseEther(rollAmountString);
+  let rollAmount: bigint;
+
+  before(async function () {
+    ({ ethers } = await network.create());
+    provider = ethers.provider;
+    rollAmount = ethers.parseEther(rollAmountString);
+  });
 
   async function deployContracts() {
     [deployer] = await ethers.getSigners();
     const DiceGame = await ethers.getContractFactory("DiceGame");
-    diceGame = await DiceGame.deploy();
+    diceGame = (await DiceGame.deploy()) as unknown as DiceGame;
 
     const contractAddress = process.env.CONTRACT_ADDRESS;
     let contractArtifact;
@@ -29,8 +35,8 @@ describe("🚩 Challenge: 🎲 Dice Game", function () {
     }
 
     const diceGameAddress = await diceGame.getAddress();
-    const RiggedRoll = (await ethers.getContractFactory(contractArtifact)) as RiggedRoll__factory;
-    riggedRoll = await RiggedRoll.deploy(diceGameAddress);
+    const RiggedRoll = (await ethers.getContractFactory(contractArtifact)) as unknown as RiggedRoll__factory;
+    riggedRoll = (await RiggedRoll.deploy(diceGameAddress)) as unknown as RiggedRoll;
   }
 
   async function fundRiggedContract() {

--- a/extension/packages/nextjs/next.config.ts.args.mjs
+++ b/extension/packages/nextjs/next.config.ts.args.mjs
@@ -2,7 +2,4 @@ export const configOverrides = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
 };


### PR DESCRIPTION
## Summary
- Migrate both deploys to `rocketh`'s `deployScript`. Use `viem`'s `parseEther` / `formatEther` and `env.network.provider.request` for `eth_getBalance`.
- `01_deploy_riggedRoll.ts` uses `env.get("DiceGame")` to look up the prior deployment.
- Migrate test: `network.create()` in `before`, drop `import hre from "hardhat"`, `HardhatEthersSigner` import path `/signers` → `/types`, cast deploys with `as unknown as`.
- Remove `eslint.ignoreDuringBuilds` from `next.config.ts.args.mjs`.

## Test plan
- [ ] `yarn deploy` deploys `DiceGame` with 0.05 ETH initial balance
- [ ] `yarn hardhat:test` passes