### PR TITLE
feat: crowdfunding migration to hh v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Before you begin, you need to install the following tools:
 Then download the challenge to your computer and install dependencies by running:
 
 ```sh
-npx create-eth@2.0.18 -e challenge-crowdfunding challenge-crowdfunding
+npx create-eth@2.0.20 -e challenge-crowdfunding challenge-crowdfunding
 ```
 
 > When prompted, choose your preferred Solidity framework: **Hardhat** or **Foundry**.

--- a/extension/packages/hardhat/deploy/00_deploy_funding_recipient.ts
+++ b/extension/packages/hardhat/deploy/00_deploy_funding_recipient.ts
@@ -1,22 +1,17 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
+import { artifacts, deployScript } from "../rocketh/deploy.js";
 
 /**
  * Deploys a contract named "FundingRecipient" using the deployer account.
- *
- * @param hre HardhatRuntimeEnvironment object.
  */
-const deployFundingRecipient: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployer } = await hre.getNamedAccounts();
-  const { deploy } = hre.deployments;
+export default deployScript(
+  async ({ deploy, namedAccounts }) => {
+    const { deployer } = namedAccounts;
 
-  await deploy("FundingRecipient", {
-    from: deployer,
-    log: true,
-    autoMine: true,
-  });
-};
-
-export default deployFundingRecipient;
-
-deployFundingRecipient.tags = ["FundingRecipient"];
+    await deploy("FundingRecipient", {
+      account: deployer,
+      artifact: artifacts.FundingRecipient,
+      args: [],
+    });
+  },
+  { tags: ["FundingRecipient"] },
+);

--- a/extension/packages/hardhat/deploy/01_deploy_crowdfund.ts
+++ b/extension/packages/hardhat/deploy/01_deploy_crowdfund.ts
@@ -1,25 +1,19 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
+import { artifacts, deployScript } from "../rocketh/deploy.js";
 
 /**
  * Deploys a contract named "CrowdFund" using the deployer account.
- *
- * @param hre HardhatRuntimeEnvironment object.
  */
-const deployCrowdFund: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployer } = await hre.getNamedAccounts();
-  const { deploy, get } = hre.deployments;
+export default deployScript(
+  async ({ deploy, get, namedAccounts }) => {
+    const { deployer } = namedAccounts;
 
-  const fundingRecipient = await get("FundingRecipient");
+    const fundingRecipient = get("FundingRecipient");
 
-  await deploy("CrowdFund", {
-    from: deployer,
-    args: [fundingRecipient.address],
-    log: true,
-    autoMine: true,
-  });
-};
-
-export default deployCrowdFund;
-
-deployCrowdFund.tags = ["CrowdFund"];
+    await deploy("CrowdFund", {
+      account: deployer,
+      artifact: artifacts.CrowdFund,
+      args: [fundingRecipient.address],
+    });
+  },
+  { tags: ["CrowdFund"] },
+);

--- a/extension/packages/hardhat/test/CrowdFund.ts
+++ b/extension/packages/hardhat/test/CrowdFund.ts
@@ -1,13 +1,20 @@
 //
 // This script executes when you run 'yarn test'
 //
-import { ethers, network } from "hardhat";
+import { network } from "hardhat";
 import { expect } from "chai";
-import { FundingRecipient, CrowdFund } from "../typechain-types";
+import type { FundingRecipient, CrowdFund } from "../types/ethers-contracts/index.js";
 
 describe("🚩 Challenge: 📣 Crowdfunding App", function () {
+  let ethers: Awaited<ReturnType<typeof network.create>>["ethers"];
+  let provider: Awaited<ReturnType<typeof network.create>>["provider"];
+
   let fundingRecipient: FundingRecipient;
   let crowdFundContract: CrowdFund;
+
+  before(async function () {
+    ({ ethers, provider } = await network.create());
+  });
 
   describe("CrowdFund", function () {
     const contractAddress = process.env.CONTRACT_ADDRESS;
@@ -22,10 +29,10 @@ describe("🚩 Challenge: 📣 Crowdfunding App", function () {
 
     const deployContracts = async () => {
       const FundingRecipientFactory = await ethers.getContractFactory("FundingRecipient");
-      fundingRecipient = (await FundingRecipientFactory.deploy()) as FundingRecipient;
+      fundingRecipient = (await FundingRecipientFactory.deploy()) as unknown as FundingRecipient;
 
       const CrowdFundFactory = await ethers.getContractFactory(contractArtifact);
-      crowdFundContract = (await CrowdFundFactory.deploy(await fundingRecipient.getAddress())) as CrowdFund;
+      crowdFundContract = (await CrowdFundFactory.deploy(await fundingRecipient.getAddress())) as unknown as CrowdFund;
     };
 
     describe("Checkpoint 1: 🤝 Contributing 💵", function () {
@@ -139,7 +146,7 @@ describe("🚩 Challenge: 📣 Crowdfunding App", function () {
 
         const writeStorageAt = async (slot: bigint, value: string) => {
           const slotHex = ethers.zeroPadValue(ethers.toBeHex(slot), 32);
-          await network.provider.send("hardhat_setStorageAt", [target, slotHex, value]);
+          await provider.request({ method: "hardhat_setStorageAt", params: [target, slotHex, value] });
         };
 
         const hexToBytes32 = (hex: string) => {
@@ -265,8 +272,8 @@ describe("🚩 Challenge: 📣 Crowdfunding App", function () {
         const t1 = await crowdFundContract.timeLeft();
         expect(Number(t1)).to.be.greaterThan(0);
 
-        await network.provider.send("evm_increaseTime", [5]);
-        await network.provider.send("evm_mine");
+        await provider.request({ method: "evm_increaseTime", params: [5] });
+        await provider.request({ method: "evm_mine" });
 
         const t2 = await crowdFundContract.timeLeft();
         expect(Number(t2)).to.be.lessThan(Number(t1));
@@ -283,8 +290,8 @@ describe("🚩 Challenge: 📣 Crowdfunding App", function () {
         const amount = ethers.parseEther("1");
         await crowdFundContract.contribute({ value: amount });
 
-        await network.provider.send("evm_increaseTime", [72 * 3600]);
-        await network.provider.send("evm_mine");
+        await provider.request({ method: "evm_increaseTime", params: [72 * 3600] });
+        await provider.request({ method: "evm_mine" });
 
         const timeLeft2 = await crowdFundContract.timeLeft();
         expect(
@@ -316,8 +323,8 @@ describe("🚩 Challenge: 📣 Crowdfunding App", function () {
           value: ethers.parseEther("0.001"),
         });
 
-        await network.provider.send("evm_increaseTime", [72 * 3600]);
-        await network.provider.send("evm_mine");
+        await provider.request({ method: "evm_increaseTime", params: [72 * 3600] });
+        await provider.request({ method: "evm_mine" });
 
         await crowdFundContract.execute();
 

--- a/extension/packages/nextjs/next.config.ts.args.mjs
+++ b/extension/packages/nextjs/next.config.ts.args.mjs
@@ -2,7 +2,4 @@ export const configOverrides = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
 };


### PR DESCRIPTION
## Summary
- Migrate both deploys to `rocketh`'s `deployScript`. `01_deploy_crowdfund.ts` uses `env.get("FundingRecipient")` (synchronous in rocketh) to look up the prior deployment.
- Migrate test: `network.create()` in `before` destructuring both `ethers` and `provider`; replace `network.provider.send(method, params)` with `provider.request({ method, params })`; cast deploys with `as unknown as`.
- Remove `eslint.ignoreDuringBuilds` from `next.config.ts.args.mjs`.

## Test plan
- [ ] `yarn deploy` deploys `FundingRecipient` then `CrowdFund` wired to it
- [ ] `yarn hardhat:test` passes (including the `hardhat_setStorageAt` storage-walk test and the time-warped withdrawal tests)