### PR TITLE
feat: tokenization migration to hh v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Before you begin, you need to install the following tools:
 Then download the challenge to your computer and install dependencies by running:
 
 ```sh
-npx create-eth@2.0.18 -e challenge-tokenization challenge-tokenization
+npx create-eth@2.0.20 -e challenge-tokenization challenge-tokenization
 ```
 
 > When prompted, choose your preferred Solidity framework: **Hardhat** or **Foundry**.

--- a/extension/packages/hardhat/deploy/01_deploy_your_collectible.ts
+++ b/extension/packages/hardhat/deploy/01_deploy_your_collectible.ts
@@ -1,43 +1,28 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { Contract } from "ethers";
+import { artifacts, deployScript } from "../rocketh/deploy.js";
 
 /**
- * Deploys a contract named "YourCollectible" using the deployer account and
- * constructor arguments set to the deployer address
+ * Deploys a contract named "YourCollectible".
  *
- * @param hre HardhatRuntimeEnvironment object.
+ * On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+ *
+ * When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
+ * should have sufficient balance to pay for the gas fees for contract creation.
+ *
+ * You can generate a random account with `yarn generate` which will fill DEPLOYER_PRIVATE_KEY_ENCRYPTED
+ * in the .env file (used in hardhat.config.ts).
+ * Run `yarn account` to check the deployer balance on every network.
  */
-const deployYourCollectible: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  /*
-    On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+export default deployScript(
+  async ({ deploy, namedAccounts }) => {
+    const { deployer } = namedAccounts;
 
-    When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
-    should have sufficient balance to pay for the gas fees for contract creation.
-
-    You can generate a random account with `yarn generate` which will fill DEPLOYER_PRIVATE_KEY
-    with a random private key in the .env file (then used on hardhat.config.ts)
-    You can run the `yarn account` command to check your balance in every network.
-  */
-  const { deployer } = await hre.getNamedAccounts();
-  const { deploy } = hre.deployments;
-
-  await deploy("YourCollectible", {
-    from: deployer,
-    // Contract constructor arguments
-    args: [],
-    log: true,
-    // autoMine: can be passed to the deploy function to make the deployment process faster on local networks by
-    // automatically mining the contract deployment transaction. There is no effect on live networks.
-    autoMine: true,
-  });
-
-  // Get the deployed contract to interact with it after deploying.
-  const yourCollectible = await hre.ethers.getContract<Contract>("YourCollectible", deployer);
-};
-
-export default deployYourCollectible;
-
-// Tags are useful if you have multiple deploy files and only want to run one of them.
-// e.g. yarn deploy --tags YourCollectible
-deployYourCollectible.tags = ["YourCollectible"];
+    await deploy("YourCollectible", {
+      account: deployer,
+      artifact: artifacts.YourCollectible,
+      args: [],
+    });
+  },
+  // Tags are useful if you have multiple deploy files and only want to run one of them.
+  // e.g. yarn deploy --tags YourCollectible
+  { tags: ["YourCollectible"] },
+);

--- a/extension/packages/hardhat/test/YourCollectible.ts
+++ b/extension/packages/hardhat/test/YourCollectible.ts
@@ -2,12 +2,17 @@
 // This script executes when you run 'yarn test'
 //
 
-import { ethers } from "hardhat";
+import { network } from "hardhat";
 import { expect } from "chai";
-import { YourCollectible } from "../typechain-types";
+import type { YourCollectible } from "../types/ethers-contracts/index.js";
 
 describe("🚩 Challenge: 🎟 Tokenization 🤓", function () {
   let myContract: YourCollectible;
+  let ethers: Awaited<ReturnType<typeof network.create>>["ethers"];
+
+  before(async function () {
+    ({ ethers } = await network.create());
+  });
 
   describe("YourCollectible", function () {
     const contractAddress = process.env.CONTRACT_ADDRESS;
@@ -21,8 +26,8 @@ describe("🚩 Challenge: 🎟 Tokenization 🤓", function () {
     }
 
     it("Should deploy the contract", async function () {
-      const YourCollectible = await ethers.getContractFactory(contractArtifact);
-      myContract = await YourCollectible.deploy();
+      const YourCollectibleFactory = await ethers.getContractFactory(contractArtifact);
+      myContract = (await YourCollectibleFactory.deploy()) as unknown as YourCollectible;
       console.log("\t", " 🛰  Contract deployed on", await myContract.getAddress());
     });
 

--- a/extension/packages/hardhat/test/YourCollectible.ts
+++ b/extension/packages/hardhat/test/YourCollectible.ts
@@ -27,7 +27,7 @@ describe("🚩 Challenge: 🎟 Tokenization 🤓", function () {
 
     it("Should deploy the contract", async function () {
       const YourCollectibleFactory = await ethers.getContractFactory(contractArtifact);
-      myContract = (await YourCollectibleFactory.deploy()) as unknown as YourCollectible;
+      myContract = (await YourCollectibleFactory.deploy()) as YourCollectible;
       console.log("\t", " 🛰  Contract deployed on", await myContract.getAddress());
     });
 

--- a/extension/packages/nextjs/app/myNFTs/_components/NFTCard.tsx
+++ b/extension/packages/nextjs/app/myNFTs/_components/NFTCard.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { Collectible } from "./MyHoldings";
 import { Address, AddressInput } from "@scaffold-ui/components";
-import { hardhat } from "viem/chains";
 import { useScaffoldWriteContract, useTargetNetwork } from "~~/hooks/scaffold-eth";
 
 export const NFTCard = ({ nft }: { nft: Collectible }) => {

--- a/extension/packages/nextjs/app/page.tsx.args.mjs
+++ b/extension/packages/nextjs/app/page.tsx.args.mjs
@@ -16,9 +16,9 @@ export const description = `
         />
         <div className="max-w-3xl">
           <p className="text-center text-lg mt-8">
-            🎫 Create a unique token to learn the basics of 🏗️ Scaffold-ETH 2. You'll compile and deploy smart
-            contracts. Then, you'll use a template React app full of important
-            Ethereum components and hooks. Finally, you'll deploy an NFT to a public network to share with
+            🎫 Create a unique token to learn the basics of 🏗️ Scaffold-ETH 2. You&apos;ll compile and deploy smart
+            contracts. Then, you&apos;ll use a template React app full of important
+            Ethereum components and hooks. Finally, you&apos;ll deploy an NFT to a public network to share with
             friends! 🚀
           </p>
           <p className="text-center text-lg">

--- a/extension/packages/nextjs/app/transfers/page.tsx
+++ b/extension/packages/nextjs/app/transfers/page.tsx
@@ -2,7 +2,6 @@
 
 import { Address } from "@scaffold-ui/components";
 import type { NextPage } from "next";
-import { hardhat } from "viem/chains";
 import { useScaffoldEventHistory } from "~~/hooks/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth";
 

--- a/extension/packages/nextjs/next.config.ts.args.mjs
+++ b/extension/packages/nextjs/next.config.ts.args.mjs
@@ -2,8 +2,5 @@ export const configOverrides = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
   serverExternalPackages: ["ipfs-utils"],
 };


### PR DESCRIPTION
## Summary
- Migrate `YourCollectible` deploy from `hardhat-deploy` (`DeployFunction` / `HardhatRuntimeEnvironment`) to `rocketh`'s `deployScript`.
- Migrate test: `network.create()` in `before` hook, type-only import from `../types/ethers-contracts/index.js`, cast deploy result with `as unknown as YourCollectible`.
- Remove `eslint.ignoreDuringBuilds` from `next.config.ts.args.mjs` for Next.js 16 (keeps `serverExternalPackages: ["ipfs-utils"]`).

This is the reference PR — the other 9 challenge migrations follow the same pattern (#459, #460, #461, #462, #463, #464, #465, #466, #467).

TODO here and for other challenges before merge!
- [x] Update create-eth version

## Test plan
- [ ] `yarn deploy` deploys `YourCollectible`
- [ ] `yarn hardhat:test` passes