### PR TITLE
docs: clarify yarn deploy --reset instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ yarn start
 
 📱 Open http://localhost:3000 to see the app.
 
-> 👩‍💻 Rerun `yarn deploy` whenever you want to deploy new contracts to the frontend. If your changes aren't registering or you want a completely fresh deployment, run `yarn deploy --reset`.
+> 👩‍💻 Rerun `yarn deploy` whenever you want to deploy contract changes to the frontend. Run `yarn deploy --reset` for a completely fresh deploy, even when contracts are unchanged.
 
 🔏 Now you are ready to edit your smart contract `CrowdFund.sol` in your contracts directory
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ yarn start
 
 📱 Open http://localhost:3000 to see the app.
 
-> 👩‍💻 Rerun `yarn deploy` whenever you want to deploy new contracts to the frontend. If you haven't made any contract changes, you can run `yarn deploy --reset` for a completely fresh deploy.
+> 👩‍💻 Rerun `yarn deploy` whenever you want to deploy new contracts to the frontend. If your changes aren't registering or you want a completely fresh deployment, run `yarn deploy --reset`.
 
 🔏 Now you are ready to edit your smart contract `CrowdFund.sol` in your contracts directory
 

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -34,7 +34,7 @@ yarn start
 
 📱 Open http://localhost:3000 to see the app.
 
-> 👩‍💻 Rerun \`yarn deploy\` whenever you want to deploy new contracts to the frontend. If you haven't made any contract changes, you can run \`yarn deploy --reset\` for a completely fresh deploy.
+> 👩‍💻 Rerun \`yarn deploy\` whenever you want to deploy contract changes to the frontend. Run \`yarn deploy --reset\` for a completely fresh deploy, even when contracts are unchanged.
 
 🔏 Now you are ready to edit your smart contract \`CrowdFund.sol\` in \`packages/${solidityFramework}/contracts\`
 


### PR DESCRIPTION
Hi team! The current text states that `--reset` should be run if you haven't made contract changes. This is confusing for learners because `--reset` is used to force a deployment or wipe local cache state when changes have been made or are stuck. Updated the wording for clarity. This is my first open-source contribution!

Here is how it currently looks on the website:

<img width="1343" height="111" alt="image" src="https://github.com/user-attachments/assets/f129ca26-96e4-480b-a57c-1641cd5f6a19" />
