### PR TITLE
fail ethToToken test when ETH reserves ignore msg.value

### DIFF
--- a/extension/packages/foundry/test/DEX.t.sol
+++ b/extension/packages/foundry/test/DEX.t.sol
@@ -97,17 +97,21 @@ contract DEXTest is Test {
     function test_Checkpoint4_EthToTokenEmitsAndTransfers() public {
         _initDex();
 
+        uint256 xInput = 1 ether;
+        uint256 xReserves = address(dex).balance;
+        uint256 yReserves = balloons.balanceOf(address(dex));
+        uint256 expectedYOutput = dex.price(xInput, xReserves, yReserves);
+
         uint256 userBalBefore = balloons.balanceOf(user2);
 
         vm.prank(user2);
         vm.recordLogs();
-        dex.ethToToken{ value: 1 ether }();
+        dex.ethToToken{ value: xInput }();
 
         uint256 userBalAfter = balloons.balanceOf(user2);
-        assertGt(userBalAfter, userBalBefore, "User should have more tokens after swap");
+        assertEq(userBalAfter, userBalBefore + expectedYOutput, "ethToToken should match expected output");
 
-        // DEX should have 6 ETH after swap
-        assertEq(address(dex).balance, 6 ether, "DEX should have 6 ETH after swap");
+        assertEq(address(dex).balance, xReserves + xInput, "DEX ETH should increase by swap input");
 
         // Check EthToTokenSwap event was emitted
         Vm.Log[] memory entries = vm.getRecordedLogs();

--- a/extension/packages/hardhat/test/DEX.ts
+++ b/extension/packages/hardhat/test/DEX.ts
@@ -117,16 +117,22 @@ describe("🚩 Challenge: ⚖️ 🪙 DEX", function () {
     it("Checkpoint4: ethToToken emits EthToTokenSwap and transfers tokens", async function () {
       const { user2, balloons, dex, dexAddress } = await deployInitializedFixture();
 
+      const xInput = ethers.parseEther("1");
+      const xReserves = await ethers.provider.getBalance(dexAddress);
+      const yReserves = await balloons.balanceOf(dexAddress);
+      const expectedYOutput = await dex.price(xInput, xReserves, yReserves);
+
       const userBalBefore = await balloons.balanceOf(user2.address);
-      const tx = dex.connect(user2).ethToToken({ value: ethers.parseEther("1") });
-      await expect(tx).to.emit(dex, "EthToTokenSwap").withArgs(user2.address, anyValue, ethers.parseEther("1"));
+      const tx = dex.connect(user2).ethToToken({ value: xInput });
+      await expect(tx)
+        .to.emit(dex, "EthToTokenSwap")
+        .withArgs(user2.address, expectedYOutput, xInput);
       await tx;
 
       const userBalAfter = await balloons.balanceOf(user2.address);
-      expect(userBalAfter).to.be.gt(userBalBefore);
+      expect(userBalAfter).to.equal(userBalBefore + expectedYOutput);
 
-      // DEX should have more ETH after swap.
-      expect(await ethers.provider.getBalance(dexAddress)).to.equal(ethers.parseEther("6"));
+      expect(await ethers.provider.getBalance(dexAddress)).to.equal(xReserves + xInput);
     });
 
     it("Checkpoint4: tokenToEth reverts on 0 tokens with InvalidTokenAmount", async function () {


### PR DESCRIPTION
## Summary

Tightens the checkpoint 4 `ethToToken` tests in Foundry and Hardhat so a wrong ETH reserve calculation no longer passes as long as the user receives some tokens.

## Why change this?

The checkpoint 4 `ethToToken` test only checked that the user received more tokens. That works as a smoke test, but it misses a common mistake: using `address(this).balance` as the ETH reserve without subtracting `msg.value`. In that case `price()` runs against the wrong pool size (for example 6 ETH instead of 5 right after `init`). The user still gets tokens, so the old assertion passed even though the swap math was off. I only caught this when I happened to read the hint after already getting the test green with the wrong implementation.

## What changed

In Foundry and Hardhat, the test now reads the DEX’s ETH and token balances before the swap, computes the expected output with `price()`, and asserts the user’s balance increases by exactly that amount. The DEX ETH balance is checked as `xReserves + xInput` instead of a hardcoded 6 ETH. Hardhat also asserts the `EthToTokenSwap` event includes the expected token amount.

## How to verify

Implement `ethToToken` along these lines (the important part is `ethReserves = address(this).balance - msg.value`), then run checkpoint 4 in both runners:

```solidity
function ethToToken() public payable returns (uint256 tokenOutput) {
    if (msg.value == 0) {
        revert InvalidEthAmount();
    }

    uint256 ethReserves = address(this).balance - msg.value;
    uint256 tokenReserves = token.balanceOf(address(this));

    tokenOutput = price(msg.value, ethReserves, tokenReserves);

    bool success = token.transfer(msg.sender, tokenOutput);
    if (!success) {
        revert EthTransferFailed(msg.sender, tokenOutput);
    }

    emit EthToTokenSwap(msg.sender, tokenOutput, msg.value);
}
```

To confirm the test actually guards this, temporarily remove the `- msg.value` and checkpoint 4 should fail on the balance assertion.