### PR TITLE
Stablecoins New UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Deploy your contracts to a testnet then build and upload your app to a public we
 📥 Then download the challenge to your computer and install dependencies by running:
 
 ```sh
-npx create-eth@2.0.18 -e scaffold-eth/se-2-challenges:challenge-stablecoins challenge-stablecoins
+npx create-eth@2.0.21 -e scaffold-eth/se-2-challenges:challenge-stablecoins challenge-stablecoins
 cd challenge-stablecoins
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ yarn start
 
 📱 Open http://localhost:3000 to see the app.
 
+> _Note: the UI in screenshots may differ slightly from the current version._
+
 > 👩‍💻 Rerun `yarn deploy` whenever you want to deploy contract changes to the frontend. Run `yarn deploy --reset` for a completely fresh deploy, even when contracts are unchanged.
 
 ---

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -60,6 +60,8 @@ yarn start
 
 📱 Open http://localhost:3000 to see the app.
 
+> _Note: the UI in screenshots may differ slightly from the current version._
+
 > 👩‍💻 Rerun \`yarn deploy\` whenever you want to deploy contract changes to the frontend. Run \`yarn deploy --reset\` for a completely fresh deploy, even when contracts are unchanged.
 
 ---

--- a/extension/packages/nextjs/app/_components/Modals/TokenSwapModal.tsx
+++ b/extension/packages/nextjs/app/_components/Modals/TokenSwapModal.tsx
@@ -164,7 +164,7 @@ export const TokenSwapModal = ({ tokenBalance, connectedAddress, ETHprice, modal
                   {sellToken === "MyUSD" ? "ETH" : "MyUSD"}
                 </span>
               </div>
-              <button className="h-10 btn btn-primary btn-sm px-2 rounded-full" onClick={handleSwap} disabled={loading}>
+              <button className="h-10 btn btn-primary btn-sm px-2" onClick={handleSwap} disabled={loading}>
                 {!loading ? (
                   <ArrowsRightLeftIcon className="h-6 w-6" />
                 ) : (

--- a/extension/packages/nextjs/app/_components/Modals/TokenSwapModal.tsx
+++ b/extension/packages/nextjs/app/_components/Modals/TokenSwapModal.tsx
@@ -112,7 +112,7 @@ export const TokenSwapModal = ({ tokenBalance, connectedAddress, ETHprice, modal
           <h3 className="text-xl font-bold mb-3">Simple Swap</h3>
           <div className="absolute top-3 right-3 flex items-center space-x-2">
             <TooltipInfo top={0} right={0} infoText={`Here you can swap ${tokenName} for ETH and vice versa`} />
-            <label htmlFor={`${modalId}`} className="btn btn-ghost btn-sm btn-circle">
+            <label htmlFor={`${modalId}`} className="btn btn-ghost btn-sm btn-square">
               ✕
             </label>
           </div>
@@ -145,7 +145,7 @@ export const TokenSwapModal = ({ tokenBalance, connectedAddress, ETHprice, modal
                 </span>
               </div>
               <div className="flex justify-center">
-                <button className="btn btn-circle btn-sm" onClick={handleChangeSellToken}>
+                <button className="btn btn-square btn-sm" onClick={handleChangeSellToken}>
                   <ArrowDownIcon className="h-4 w-4 my-0" />
                 </button>
               </div>

--- a/extension/packages/nextjs/app/_components/Modals/TokenTransferModal.tsx
+++ b/extension/packages/nextjs/app/_components/Modals/TokenTransferModal.tsx
@@ -47,7 +47,7 @@ export const TokenTransferModal = ({ tokenBalance, connectedAddress, modalId }: 
           <h3 className="text-xl font-bold mb-3">Send {tokenName}</h3>
           <div className="absolute top-3 right-3 flex items-center space-x-2">
             <TooltipInfo top={0} right={0} infoText={`Here you can send ${tokenName} to another address`} />
-            <label htmlFor={`${modalId}`} className="btn btn-ghost btn-sm btn-circle">
+            <label htmlFor={`${modalId}`} className="btn btn-ghost btn-sm btn-square">
               ✕
             </label>
           </div>

--- a/extension/packages/nextjs/app/_components/Modals/TokenTransferModal.tsx
+++ b/extension/packages/nextjs/app/_components/Modals/TokenTransferModal.tsx
@@ -78,7 +78,7 @@ export const TokenTransferModal = ({ tokenBalance, connectedAddress, modalId }: 
                 placeholder="Amount"
                 disableMultiplyBy1e18
               />
-              <button className="h-10 btn btn-primary btn-sm px-2 rounded-full" onClick={handleSend} disabled={loading}>
+              <button className="h-10 btn btn-primary btn-sm px-2" onClick={handleSend} disabled={loading}>
                 {!loading ? (
                   <BanknotesIcon className="h-6 w-6" />
                 ) : (

--- a/extension/packages/nextjs/app/_components/RateControls.tsx
+++ b/extension/packages/nextjs/app/_components/RateControls.tsx
@@ -44,10 +44,10 @@ const RateInput: React.FC<RateInputProps> = ({
       <div className="flex mx-2 w-1/5 gap-1">
         {isEditing ? (
           <>
-            <label className="btn btn-sm btn-circle" onClick={() => onSave(newValue)}>
+            <label className="btn btn-sm btn-square" onClick={() => onSave(newValue)}>
               <CheckIcon className="h-3 w-3" />
             </label>
-            <label className="btn btn-sm btn-circle" onClick={onCancel}>
+            <label className="btn btn-sm btn-square" onClick={onCancel}>
               <XMarkIcon className="h-3 w-3" />
             </label>
           </>

--- a/extension/packages/nextjs/app/_components/SideButtons.tsx
+++ b/extension/packages/nextjs/app/_components/SideButtons.tsx
@@ -86,7 +86,7 @@ const SideButtons: React.FC = () => {
 
   return (
     <div
-      className="absolute top-[120px] right-0 bg-base-100 w-fit border-base-300 border shadow-md rounded-xl"
+      className="absolute top-[120px] right-0 bg-base-100 w-fit border-base-300 border shadow-md"
       onMouseEnter={handleContainerEnter}
       onMouseLeave={handleContainerLeave}
     >

--- a/extension/packages/nextjs/app/_components/SideButtons.tsx
+++ b/extension/packages/nextjs/app/_components/SideButtons.tsx
@@ -28,7 +28,7 @@ const SideButton: React.FC<{
   const Icon = config.icon;
   return (
     <button
-      className={`btn btn-circle btn-primary transition-transform duration-300 hover:scale-110 ${isHovered ? "ring-2 ring-primary" : ""}`}
+      className={`btn btn-square btn-primary transition-transform duration-300 hover:scale-110 ${isHovered ? "ring-2 ring-primary" : ""}`}
       onMouseEnter={() => onHover(config.id)}
     >
       <Icon className="h-6 w-6" />

--- a/extension/packages/nextjs/app/_components/SupplyGraph.tsx
+++ b/extension/packages/nextjs/app/_components/SupplyGraph.tsx
@@ -46,7 +46,7 @@ const CustomTooltip = ({ active, payload, label }: TooltipProps<number, string>)
     const total = payload.find(p => p.dataKey === "totalSupply")?.value || 0;
 
     return (
-      <div className="bg-base-200 border border-base-300 rounded-lg px-3 my-0 shadow-lg">
+      <div className="bg-base-200 border border-base-300 px-3 my-0 shadow-lg">
         <p className="font-semibold text-sm mt-2 mb-1">Block {label}</p>
         <p className="text-sm my-0">
           <span style={{ color: ORANGE_COLOR }}>●</span> Total: {formatDisplayValue(total)} MyUSD

--- a/extension/packages/nextjs/app/_components/TokenActions.tsx
+++ b/extension/packages/nextjs/app/_components/TokenActions.tsx
@@ -62,11 +62,11 @@ const TokenActions = () => {
             </span>
           </span>
           <div className="flex gap-2">
-            <label htmlFor={`${transferModalId}`} className="btn btn-primary btn-circle btn-xs">
+            <label htmlFor={`${transferModalId}`} className="btn btn-primary btn-square btn-xs">
               <PaperAirplaneIcon className="h-3 w-3" />
             </label>
             {ConnectedChain?.id === hardhat.id && (
-              <label htmlFor={`${swapModalId}`} className="btn btn-primary btn-circle btn-xs">
+              <label htmlFor={`${swapModalId}`} className="btn btn-primary btn-square btn-xs">
                 <ArrowsRightLeftIcon className="h-3 w-3" />
               </label>
             )}

--- a/extension/packages/nextjs/app/_components/TokenActions.tsx
+++ b/extension/packages/nextjs/app/_components/TokenActions.tsx
@@ -39,14 +39,14 @@ const TokenActions = () => {
   const { showAnimation } = useAnimationConfig(stablecoinBalance);
 
   return (
-    <div className="absolute mt-10 right-0 bg-base-100 w-fit border-base-300 border shadow-md rounded-xl z-10">
+    <div className="absolute mt-10 right-0 bg-base-100 w-fit border-base-300 border shadow-md z-10">
       <div className="w-[150px] py-5 flex flex-col items-center gap-1 indicator">
         <TooltipInfo top={3} right={3} infoText={`Here you can send ${tokenName} to any address or swap it`} />
         <div className="flex flex-col items-center gap-1">
           <span className="text-sm font-bold">{tokenName} Wallet</span>
           <span className="flex text-sm">
             <span
-              className={`transition bg-transparent ${showAnimation ? "bg-warning rounded-xs animate-pulse-fast" : ""}`}
+              className={`transition bg-transparent ${showAnimation ? "bg-warning animate-pulse-fast" : ""}`}
             >
               {tokenBalance}
             </span>
@@ -56,7 +56,7 @@ const TokenActions = () => {
           <span className="flex items-center text-xs">
             1 {tokenName} = &nbsp;
             <span
-              className={`transition bg-transparent ${isNaN(myUSDPrice) ? "bg-gray-200 rounded animate-pulse" : ""}`}
+              className={`transition bg-transparent ${isNaN(myUSDPrice) ? "bg-gray-200 animate-pulse" : ""}`}
             >
               {isNaN(myUSDPrice) ? "..." : `$${myUSDPrice.toFixed(5)}`}
             </span>

--- a/extension/packages/nextjs/app/page.tsx.args.mjs
+++ b/extension/packages/nextjs/app/page.tsx.args.mjs
@@ -12,7 +12,7 @@ export const description = `
           width="727"
           height="231"
           alt="challenge banner"
-          className="rounded-xl border-4 border-primary"
+          className="border-4 border-primary"
         />
         <div className="max-w-3xl">
           <p className="text-center text-lg mt-8">

--- a/extension/packages/nextjs/package.json
+++ b/extension/packages/nextjs/package.json
@@ -1,8 +1,5 @@
 {
     "dependencies": {
-        "@scaffold-ui/components": "0.1.11",
-        "@scaffold-ui/debug-contracts": "0.1.10",
-        "@scaffold-ui/hooks": "0.1.8",
         "recharts": "^2.15.1"
     }
 }

--- a/extension/packages/nextjs/styles/globals.css.args.mjs
+++ b/extension/packages/nextjs/styles/globals.css.args.mjs
@@ -19,6 +19,10 @@ export const postContent = `
   --color-warning: #ffcf72;
   --color-error: #ff8863;
 
+  --radius-field: 0rem;
+  --radius-box: 0rem;
+  --radius-selector: 0rem;
+
   /* tooltip tail width */
   --tt-tailw: 6px;
 }
@@ -43,6 +47,10 @@ export const postContent = `
   --color-success: #34eeb6;
   --color-warning: #ffcf72;
   --color-error: #ff8863;
+
+  --radius-field: 0rem;
+  --radius-box: 0rem;
+  --radius-selector: 0rem;
 
   --tt-tailw: 6px;
   --tt-bg: var(--color-primary); /* if you need a tooltip bg override */

--- a/extension/packages/nextjs/styles/globals.css.args.mjs
+++ b/extension/packages/nextjs/styles/globals.css.args.mjs
@@ -19,10 +19,6 @@ export const postContent = `
   --color-warning: #ffcf72;
   --color-error: #ff8863;
 
-  /* radius / button rounding */
-  --radius-field: 9999rem;
-  --radius-box: 1rem;
-
   /* tooltip tail width */
   --tt-tailw: 6px;
 }
@@ -47,9 +43,6 @@ export const postContent = `
   --color-success: #34eeb6;
   --color-warning: #ffcf72;
   --color-error: #ff8863;
-
-  --radius-field: 9999rem;
-  --radius-box: 1rem;
 
   --tt-tailw: 6px;
   --tt-bg: var(--color-primary); /* if you need a tooltip bg override */


### PR DESCRIPTION
Backmerge of `base-challenge-template-new-ui` + border-radius cleanup for the new (square) UI.

## Changes
- Backmerge `base-challenge-template-new-ui` → removes daisyUI `--radius-field` / `--radius-box` vars from `globals.css.args.mjs`
- Remove `rounded-*` / bare `rounded` Tailwind classes and inline `borderRadius` styles (kept `rounded-full` only on loading spinners)
- Bump `create-eth@2.0.18` → `2.0.21` in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)