### PR TITLE
Prediction Markets New UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Before you begin, you need to install the following tools:
 Then download the challenge to your computer and install dependencies by running:
 
 ```sh
-npx create-eth@2.0.18 -e challenge-prediction-markets challenge-prediction-markets
+npx create-eth@2.0.21 -e challenge-prediction-markets challenge-prediction-markets
 cd challenge-prediction-markets
 ```
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ yarn start
 
 📱 Open [http://localhost:3000](http://localhost:3000/) to see the app.
 
+> _Note: the UI in screenshots may differ slightly from the current version._
+
 > 👩‍💻 Rerun `yarn deploy` whenever you want to deploy contract changes to the frontend. Run `yarn deploy --reset` for a completely fresh deploy, even when contracts are unchanged.
 
 Head to the **`Debug Contracts`** tab and you should find a smart contract named **`PredictionMarket`**. This is our main contract and the one we'll be working on throughout the challenge. Since we haven't implemented any functions yet, they all shouldn't work, nor will you see all the necessary state variables.

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -96,6 +96,8 @@ yarn start
 
 📱 Open [http://localhost:3000](http://localhost:3000/) to see the app.
 
+> _Note: the UI in screenshots may differ slightly from the current version._
+
 > 👩‍💻 Rerun \`yarn deploy\` whenever you want to deploy contract changes to the frontend. Run \`yarn deploy --reset\` for a completely fresh deploy, even when contracts are unchanged.
 
 Head to the **\`Debug Contracts\`** tab and you should find a smart contract named **\`PredictionMarket\`**. This is our main contract and the one we'll be working on throughout the challenge. Since we haven't implemented any functions yet, they all shouldn't work, nor will you see all the necessary state variables.

--- a/extension/packages/nextjs/app/page.tsx.args.mjs
+++ b/extension/packages/nextjs/app/page.tsx.args.mjs
@@ -12,7 +12,7 @@ export const description = `
           width="727"
           height="231"
           alt="challenge banner"
-          className="rounded-xl border-4 border-primary"
+          className="border-4 border-primary"
         />
         <div className="max-w-3xl">
           <p className="text-center text-lg mt-8">

--- a/extension/packages/nextjs/components/liquidity-provider/LPAddress.tsx
+++ b/extension/packages/nextjs/components/liquidity-provider/LPAddress.tsx
@@ -18,7 +18,7 @@ export function LPAddress() {
 
   if (!owner)
     return (
-      <div className="flex flex-col bg-base-100 p-4 rounded-xl">
+      <div className="flex flex-col bg-base-100 p-4">
         <h3 className="text-xl font-medium">Prediction Market Info</h3>
         <p className="text-base-content">No prediction market found</p>
       </div>

--- a/extension/packages/nextjs/components/liquidity-provider/PredictionMarketInfoLP.tsx
+++ b/extension/packages/nextjs/components/liquidity-provider/PredictionMarketInfoLP.tsx
@@ -112,7 +112,7 @@ export function PredictionMarketInfoLP() {
           {!isReported ? (
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {/* Yes Token */}
-              <div className="bg-base-200 p-4 rounded-lg border-4 border-green-500">
+              <div className="bg-base-200 p-4 border-4 border-green-500">
                 <h2 className="text-2xl font-semibold mb-2">&quot;{yesOutcome}&quot; Token</h2>
                 <h3 className="text-lg mb-2">
                   Total Supply:
@@ -162,7 +162,7 @@ export function PredictionMarketInfoLP() {
               </div>
 
               {/* No Token */}
-              <div className="bg-base-200 p-4 rounded-lg border-4 border-red-500">
+              <div className="bg-base-200 p-4 border-4 border-red-500">
                 <h2 className="text-2xl font-semibold mb-2">&quot;{noOutcome}&quot; Token</h2>
                 <h3 className="text-lg mb-2">
                   Total Supply:
@@ -208,7 +208,7 @@ export function PredictionMarketInfoLP() {
               </div>
             </div>
           ) : (
-            <div className="bg-base-200 p-4 rounded-lg">
+            <div className="bg-base-200 p-4">
               <h2 className="text-2xl font-semibold mb-2">Oracle reported: {winningOption}</h2>
               <h3 className="text-lg mb-2">
                 Value of {winningOption} tokens held by prediction market:{" "}

--- a/extension/packages/nextjs/components/liquidity-provider/ResolveMarketAndWithdraw.tsx
+++ b/extension/packages/nextjs/components/liquidity-provider/ResolveMarketAndWithdraw.tsx
@@ -62,7 +62,7 @@ export function ResolveMarketAndWithdraw() {
     <div className="card bg-base-100 w-full shadow-xl indicator">
       <div className="card-body">
         {!isLiquidityProvider ? (
-          <div className="max-w-6xl mx-auto bg-base-100 rounded-xl">
+          <div className="max-w-6xl mx-auto bg-base-100">
             <p className="text-xl font-bold text-center">❗️ Only the liquidity provider can resolve the market</p>
           </div>
         ) : (

--- a/extension/packages/nextjs/components/race/Race.tsx
+++ b/extension/packages/nextjs/components/race/Race.tsx
@@ -244,7 +244,7 @@ const RaceTrack: React.FC = () => {
             </div>
           </div>
 
-          <div className="rounded-lg overflow-hidden">
+          <div className="overflow-hidden">
             <Image
               src={resolvedTheme === "dark" ? BackgroundImageDark : BackgroundImage}
               alt="Mountain Background"

--- a/extension/packages/nextjs/components/race/RaceEffects.tsx
+++ b/extension/packages/nextjs/components/race/RaceEffects.tsx
@@ -33,7 +33,7 @@ const RaceEffects: React.FC<RaceEffectsProps> = ({ isRacing }) => {
         {Array.from({ length: 15 }).map((_, index) => (
           <div
             key={index}
-            className="absolute rounded-full bg-gray-300 opacity-40"
+            className="absolute bg-gray-300 opacity-40"
             style={{
               top: `${50 + (Math.random() * 40 - 20)}%`,
               left: `${Math.random() * 100}%`,

--- a/extension/packages/nextjs/components/user/OverviewBuySellShares.tsx
+++ b/extension/packages/nextjs/components/user/OverviewBuySellShares.tsx
@@ -60,12 +60,12 @@ export function OverviewBuySellShares() {
             type="radio"
             name="token_tabs"
             role="tab"
-            className="tab font-lexend font-semibold text-green-500 min-w-40 rounded-tl-md rounded-tr-md bg-base-300 checked:bg-green-500 checked:text-white"
+            className="tab font-lexend font-semibold text-green-500 min-w-40 bg-base-300 checked:bg-green-500 checked:text-white"
             aria-label={`"${yesOutcome}" Token`}
             defaultChecked
           />
           <div role="tabpanel" className="tab-content border-l-0">
-            <div className="rounded-bl-lg rounded-br-lg p-4 border-4 border-green-500">
+            <div className="p-4 border-4 border-green-500">
               <PredictionBuySellShare optionIndex={0} colorScheme="green" />
             </div>
           </div>
@@ -74,11 +74,11 @@ export function OverviewBuySellShares() {
             type="radio"
             name="token_tabs"
             role="tab"
-            className="tab font-lexend font-semibold text-red-500 min-w-40 rounded-md bg-base-300 checked:bg-red-500 checked:text-white ml-4"
+            className="tab font-lexend font-semibold text-red-500 min-w-40 bg-base-300 checked:bg-red-500 checked:text-white ml-4"
             aria-label={`"${noOutcome}" Token`}
           />
           <div role="tabpanel" className="tab-content border-l-0">
-            <div className="rounded-bl-lg rounded-br-lg p-4 border-4 border-red-500">
+            <div className="p-4 border-4 border-red-500">
               <PredictionBuySellShare optionIndex={1} colorScheme="red" />
             </div>
           </div>

--- a/extension/packages/nextjs/components/user/PredictionBuySellShare.tsx
+++ b/extension/packages/nextjs/components/user/PredictionBuySellShare.tsx
@@ -63,7 +63,7 @@ export function PredictionBuySellShare({ optionIndex, colorScheme }: { optionInd
 
   if (!owner)
     return (
-      <div className="max-w-lg mx-auto p-4 bg-white rounded-xl shadow-lg space-y-4">
+      <div className="max-w-lg mx-auto p-4 bg-white shadow-lg space-y-4">
         <h2 className="text-lg font-semibold text-center">No prediction market found</h2>
       </div>
     );
@@ -117,12 +117,12 @@ export function PredictionBuySellShare({ optionIndex, colorScheme }: { optionInd
               defaultChecked
             />
             <div role="tabpanel" className="tab-content pt-4">
-              <div className={`bg-${colorScheme}-50 rounded-lg`}>
+              <div className={`bg-${colorScheme}-50`}>
                 <div className="space-y-4">
                   <input
                     type="number"
                     placeholder="Amount to buy"
-                    className={`input input-bordered input-sm w-full rounded-md placeholder-${colorScheme}-500 dark:placeholder-white dark:placeholder-opacity-70`}
+                    className={`input input-bordered input-sm w-full placeholder-${colorScheme}-500 dark:placeholder-white dark:placeholder-opacity-70`}
                     onChange={e => setInputBuyAmount(BigInt(e.target.value))}
                   />
 
@@ -185,7 +185,7 @@ export function PredictionBuySellShare({ optionIndex, colorScheme }: { optionInd
                   <input
                     type="number"
                     placeholder="Amount to sell"
-                    className={`input input-bordered input-sm w-full rounded-md placeholder-${colorScheme}-500 dark:placeholder-white dark:placeholder-opacity-70`}
+                    className={`input input-bordered input-sm w-full placeholder-${colorScheme}-500 dark:placeholder-white dark:placeholder-opacity-70`}
                     onChange={e => setInputSellAmount(BigInt(e.target.value))}
                   />
 

--- a/extension/packages/nextjs/components/user/PredictionMarketInfo.tsx
+++ b/extension/packages/nextjs/components/user/PredictionMarketInfo.tsx
@@ -35,7 +35,7 @@ export function PredictionMarketInfo() {
   return (
     <div className="card bg-base-100 w-full shadow-xl indicator">
       <div className="card-body">
-        <div className="bg-base-200 py-4 px-6 rounded-lg">
+        <div className="bg-base-200 py-4 px-6">
           <div className="flex justify-between items-center">
             <div>
               <p className="text-base-content text-xl font-bold">{question}</p>

--- a/extension/packages/nextjs/components/user/ProbabilityDisplay.tsx
+++ b/extension/packages/nextjs/components/user/ProbabilityDisplay.tsx
@@ -54,7 +54,7 @@ export function ProbabilityDisplay({
   const probability = calculateProbability(token1Reserve, token2Reserve);
 
   return (
-    <div className="bg-base-200 p-4 rounded-lg text-center">
+    <div className="bg-base-200 p-4 text-center">
       <h3
         className={clsx("text-lg font-semibold mb-2", {
           "text-green-500": isReported && winningOption === "Yes",

--- a/extension/packages/nextjs/package.json
+++ b/extension/packages/nextjs/package.json
@@ -1,7 +1,0 @@
-{
-  "dependencies": {
-    "@scaffold-ui/components": "0.1.11",
-    "@scaffold-ui/debug-contracts": "0.1.10",
-    "@scaffold-ui/hooks": "0.1.8"
-  }
-}

--- a/extension/packages/nextjs/styles/globals.css.args.mjs
+++ b/extension/packages/nextjs/styles/globals.css.args.mjs
@@ -19,6 +19,10 @@ export const postContent = `
   --color-warning: #ffcf72;
   --color-error: #ff8863;
 
+  --radius-field: 0rem;
+  --radius-box: 0rem;
+  --radius-selector: 0rem;
+
   /* tooltip tail width */
   --tt-tailw: 6px;
 }
@@ -43,6 +47,10 @@ export const postContent = `
   --color-success: #34eeb6;
   --color-warning: #ffcf72;
   --color-error: #ff8863;
+
+  --radius-field: 0rem;
+  --radius-box: 0rem;
+  --radius-selector: 0rem;
 
   --tt-tailw: 6px;
   --tt-bg: var(--color-primary); /* if you need a tooltip bg override */

--- a/extension/packages/nextjs/styles/globals.css.args.mjs
+++ b/extension/packages/nextjs/styles/globals.css.args.mjs
@@ -19,10 +19,6 @@ export const postContent = `
   --color-warning: #ffcf72;
   --color-error: #ff8863;
 
-  /* radius / button rounding */
-  --radius-field: 9999rem;
-  --radius-box: 1rem;
-
   /* tooltip tail width */
   --tt-tailw: 6px;
 }
@@ -47,9 +43,6 @@ export const postContent = `
   --color-success: #34eeb6;
   --color-warning: #ffcf72;
   --color-error: #ff8863;
-
-  --radius-field: 9999rem;
-  --radius-box: 1rem;
 
   --tt-tailw: 6px;
   --tt-bg: var(--color-primary); /* if you need a tooltip bg override */


### PR DESCRIPTION
Backmerge of `base-challenge-template-new-ui` + border-radius cleanup for the new (square) UI.

## Changes
- Backmerge `base-challenge-template-new-ui` → removes daisyUI `--radius-field` / `--radius-box` vars from `globals.css.args.mjs`
- Remove `rounded-*` / bare `rounded` Tailwind classes and inline `borderRadius` styles (kept `rounded-full` only on loading spinners)
- Bump `create-eth@2.0.18` → `2.0.21` in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)