### PR TITLE
ZK Voting New UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Our contract will support three main functions:
 
 📱 Open [http://localhost:3000](http://localhost:3000/) to spin up your app.
 
+> _Note: the UI in screenshots may differ slightly from the current version._
+
 🖥️ Head over to the **Voting** page and take a look at the frontend you’ll soon bring to life.
 
 ![overview-zk](https://raw.githubusercontent.com/scaffold-eth/se-2-challenges/challenge-zk-voting/extension/packages/nextjs/public/overview-zk.png)

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If you are using vscode you may want to install the [Noir Language Support](http
 Then download the challenge to your computer and install dependencies by running:
 
 ```sh
-npx create-eth@2.0.18 -e scaffold-eth/se-2-challenges:challenge-zk-voting challenge-zk-voting
+npx create-eth@2.0.21 -e scaffold-eth/se-2-challenges:challenge-zk-voting challenge-zk-voting
 cd challenge-zk-voting
 ```
 

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -94,7 +94,7 @@ If you are using vscode you may want to install the [Noir Language Support](http
 Then download the challenge to your computer and install dependencies by running:
 
 \`\`\`javascript
-npx create-eth@2.0.18 -e scaffold-eth/se-2-challenges:challenge-zk-voting challenge-zk-voting
+npx create-eth@2.0.21 -e scaffold-eth/se-2-challenges:challenge-zk-voting challenge-zk-voting
 cd challenge-zk-voting
 \`\`\`
 

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -176,6 +176,8 @@ Our contract will support three main functions:
 
 📱 Open [http://localhost:3000](http://localhost:3000/) to spin up your app.
 
+> _Note: the UI in screenshots may differ slightly from the current version._
+
 🖥️ Head over to the **Voting** page and take a look at the frontend you’ll soon bring to life.
 
 ![overview-zk](https://raw.githubusercontent.com/scaffold-eth/se-2-challenges/challenge-zk-voting/extension/packages/nextjs/public/overview-zk.png)

--- a/extension/packages/nextjs/app/page.tsx.args.mjs
+++ b/extension/packages/nextjs/app/page.tsx.args.mjs
@@ -12,7 +12,7 @@ export const description = `
           width="727"
           height="231"
           alt="ZK Voting challenge banner"
-          className="rounded-xl border-4 border-primary"
+          className="border-4 border-primary"
         />
         <div className="max-w-3xl">
           <p className="text-center text-lg mt-8">

--- a/extension/packages/nextjs/app/voting/_challengeComponents/CreateCommitment.tsx
+++ b/extension/packages/nextjs/app/voting/_challengeComponents/CreateCommitment.tsx
@@ -111,7 +111,7 @@ export const CreateCommitment = ({ leafEvents = [] }: CreateCommitmentProps) => 
   };
 
   return (
-    <div className="bg-base-100 shadow rounded-xl p-6 space-y-5">
+    <div className="bg-base-100 shadow p-6 space-y-5">
       <div className="space-y-1 text-center">
         <h2 className="text-2xl font-bold">Register for this vote</h2>
         <p className="text-sm opacity-70">Generate your anonymous identifier and insert it into the Merkle tree.</p>

--- a/extension/packages/nextjs/app/voting/_challengeComponents/GenerateProof.tsx
+++ b/extension/packages/nextjs/app/voting/_challengeComponents/GenerateProof.tsx
@@ -161,7 +161,7 @@ export const GenerateProof = ({ leafEvents = [] }: CreateCommitmentProps) => {
   };
 
   return (
-    <div className="bg-base-100 shadow rounded-xl p-6 space-y-5">
+    <div className="bg-base-100 shadow p-6 space-y-5">
       <div className="space-y-1">
         <h2 className="text-2xl font-bold text-center"> Generate ZK proof off-chain </h2>
         <p className="text-sm opacity-70">

--- a/extension/packages/nextjs/app/voting/_challengeComponents/VoteWithBurnerHardhat.tsx
+++ b/extension/packages/nextjs/app/voting/_challengeComponents/VoteWithBurnerHardhat.tsx
@@ -138,7 +138,7 @@ export const VoteWithBurnerHardhat = ({ contractAddress }: { contractAddress?: `
   }, [contractAddress, contractInfo?.address, userAddress]);
 
   return (
-    <div className="bg-base-100 shadow rounded-xl p-6 space-y-4">
+    <div className="bg-base-100 shadow p-6 space-y-4">
       <div className="space-y-1 text-center">
         <h2 className="text-2xl font-bold">Vote</h2>
         <p className="text-sm opacity-70">Use a local burner wallet to submit the on-chain vote with the proof.</p>

--- a/extension/packages/nextjs/app/voting/_challengeComponents/VoteWithBurnerSepolia.tsx
+++ b/extension/packages/nextjs/app/voting/_challengeComponents/VoteWithBurnerSepolia.tsx
@@ -145,7 +145,7 @@ export const VoteWithBurnerSepolia = ({ contractAddress }: { contractAddress?: `
   }, [contractAddress, contractInfo?.address, userAddress, proofData, setProofData]);
 
   return (
-    <div className="bg-base-100 shadow rounded-xl p-6 space-y-4">
+    <div className="bg-base-100 shadow p-6 space-y-4">
       <div className="space-y-1 text-center">
         <h2 className="text-2xl font-bold">Vote</h2>
         <p className="text-sm opacity-70">

--- a/extension/packages/nextjs/app/voting/_components/AddVotersModal.tsx
+++ b/extension/packages/nextjs/app/voting/_components/AddVotersModal.tsx
@@ -107,7 +107,7 @@ export const AddVotersModal = () => {
               {/* dummy input to capture event onclick on modal box */}
               <input className="h-0 w-0 absolute top-0 left-0" />
               <h3 className="text-xl font-bold mb-3">Add Voters</h3>
-              <label htmlFor="add-voters-modal" className="btn btn-ghost btn-sm btn-circle absolute right-3 top-3">
+              <label htmlFor="add-voters-modal" className="btn btn-ghost btn-sm btn-square absolute right-3 top-3">
                 ✕
               </label>
 
@@ -152,7 +152,7 @@ export const AddVotersModal = () => {
 
                       <button
                         onClick={() => removeVoterEntry(index)}
-                        className="btn btn-ghost btn-sm btn-circle"
+                        className="btn btn-ghost btn-sm btn-square"
                         disabled={voters.length === 1}
                       >
                         <TrashIcon className="h-4 w-4" />

--- a/extension/packages/nextjs/app/voting/_components/AddVotersModal.tsx
+++ b/extension/packages/nextjs/app/voting/_components/AddVotersModal.tsx
@@ -118,7 +118,7 @@ export const AddVotersModal = () => {
 
                 <div className="space-y-3 max-h-96 overflow-y-auto">
                   {voters.map((voter, index) => (
-                    <div key={index} className="flex items-center gap-3 p-3 border border-base-300 rounded-lg">
+                    <div key={index} className="flex items-center gap-3 p-3 border border-base-300">
                       <div className="flex-1">
                         <AddressInput
                           placeholder="Voter Address (0x...)"

--- a/extension/packages/nextjs/app/voting/_components/ShowVotersButton.tsx
+++ b/extension/packages/nextjs/app/voting/_components/ShowVotersButton.tsx
@@ -66,7 +66,7 @@ const VoterStatus = ({ address }: { address: string }) => {
   const hasRegistered = voterData?.[1];
 
   return (
-    <div className="flex items-center justify-between p-3 border border-base-300 rounded-lg">
+    <div className="flex items-center justify-between p-3 border border-base-300">
       <div className="flex-1">
         <Address address={address as `0x${string}`} />
       </div>

--- a/extension/packages/nextjs/app/voting/_components/ShowVotersButton.tsx
+++ b/extension/packages/nextjs/app/voting/_components/ShowVotersButton.tsx
@@ -114,7 +114,7 @@ const ShowVotersModal = ({
           </h3>
           <label
             htmlFor="show-voters-modal"
-            className="btn btn-ghost btn-sm btn-circle absolute right-3 top-3"
+            className="btn btn-ghost btn-sm btn-square absolute right-3 top-3"
             onClick={() => onClose()}
           >
             ✕

--- a/extension/packages/nextjs/app/voting/_components/VoteChoice.tsx
+++ b/extension/packages/nextjs/app/voting/_components/VoteChoice.tsx
@@ -5,7 +5,7 @@ export const VoteSelector = () => {
   const setVoteChoice = useChallengeState(state => state.setVoteChoice);
 
   return (
-    <div className="bg-base-100 shadow rounded-xl p-6 space-y-4">
+    <div className="bg-base-100 shadow p-6 space-y-4">
       <div className="space-y-1 text-center">
         <h2 className="text-2xl font-bold">Choose your vote</h2>
       </div>

--- a/extension/packages/nextjs/app/voting/_components/VotingStats.tsx
+++ b/extension/packages/nextjs/app/voting/_components/VotingStats.tsx
@@ -22,7 +22,7 @@ export const VotingStats = () => {
   const noPercentage = totalVotes > 0n ? Number((no * 100n) / totalVotes) : 0;
 
   return (
-    <div className="bg-base-100 shadow rounded-xl p-4 space-y-3">
+    <div className="bg-base-100 shadow p-4 space-y-3">
       <div className="text-center">
         <h2 className="text-2xl font-bold">{q || "Loading..."}</h2>
         <div className="flex justify-center gap-10">
@@ -36,19 +36,19 @@ export const VotingStats = () => {
         <span className="text-xs opacity-70">Total Votes: {totalVotes.toString()}</span>
       </div>
       <div className="grid grid-cols-2 gap-2 text-center">
-        <div className="rounded-lg border border-base-300 p-3">
+        <div className="border border-base-300 p-3">
           <div className="text-xs opacity-70">Yes</div>
           <div className="text-xl font-bold text-success">{yes.toString()}</div>
           <div className="text-xs opacity-70">{yesPercentage.toFixed(1)}%</div>
         </div>
-        <div className="rounded-lg border border-base-300 p-3">
+        <div className="border border-base-300 p-3">
           <div className="text-xs opacity-70">No</div>
           <div className="text-xl font-bold text-error">{no.toString()}</div>
           <div className="text-xs opacity-70">{noPercentage.toFixed(1)}%</div>
         </div>
       </div>
       {totalVotes > 0n && (
-        <div className="w-full bg-base-200 rounded-full h-2 overflow-hidden flex">
+        <div className="w-full bg-base-200 h-2 overflow-hidden flex">
           <div className="bg-success h-2" style={{ width: `${yesPercentage}%` }} />
           <div className="bg-error h-2" style={{ width: `${noPercentage}%` }} />
         </div>

--- a/extension/packages/nextjs/package.json
+++ b/extension/packages/nextjs/package.json
@@ -1,8 +1,5 @@
 {
   "dependencies": {
-    "@scaffold-ui/components": "0.1.11",
-    "@scaffold-ui/debug-contracts": "0.1.10",
-    "@scaffold-ui/hooks": "0.1.8",
     "@aztec/bb.js": "0.82.0",
     "@noir-lang/noir_js": "1.0.0-beta.3",
     "@zk-kit/lean-imt": "^2.2.4",

--- a/extension/packages/nextjs/styles/globals.css.args.mjs
+++ b/extension/packages/nextjs/styles/globals.css.args.mjs
@@ -19,6 +19,10 @@ export const postContent = `
   --color-warning: #ffcf72;
   --color-error: #ff8863;
 
+  --radius-field: 0rem;
+  --radius-box: 0rem;
+  --radius-selector: 0rem;
+
   /* tooltip tail width */
   --tt-tailw: 6px;
 }
@@ -43,6 +47,10 @@ export const postContent = `
   --color-success: #34eeb6;
   --color-warning: #ffcf72;
   --color-error: #ff8863;
+
+  --radius-field: 0rem;
+  --radius-box: 0rem;
+  --radius-selector: 0rem;
 
   --tt-tailw: 6px;
   --tt-bg: var(--color-primary); /* if you need a tooltip bg override */

--- a/extension/packages/nextjs/styles/globals.css.args.mjs
+++ b/extension/packages/nextjs/styles/globals.css.args.mjs
@@ -19,10 +19,6 @@ export const postContent = `
   --color-warning: #ffcf72;
   --color-error: #ff8863;
 
-  /* radius / button rounding */
-  --radius-field: 9999rem;
-  --radius-box: 1rem;
-
   /* tooltip tail width */
   --tt-tailw: 6px;
 }
@@ -47,9 +43,6 @@ export const postContent = `
   --color-success: #34eeb6;
   --color-warning: #ffcf72;
   --color-error: #ff8863;
-
-  --radius-field: 9999rem;
-  --radius-box: 1rem;
 
   --tt-tailw: 6px;
   --tt-bg: var(--color-primary); /* if you need a tooltip bg override */


### PR DESCRIPTION
Backmerge of `base-challenge-template-new-ui` + border-radius cleanup for the new (square) UI.

## Changes
- Backmerge `base-challenge-template-new-ui` → removes daisyUI `--radius-field` / `--radius-box` vars from `globals.css.args.mjs`
- Remove `rounded-*` / bare `rounded` Tailwind classes and inline `borderRadius` styles (kept `rounded-full` only on loading spinners)
- Bump `create-eth@2.0.18` → `2.0.21` in README + README.md.args.mjs

🤖 Generated with [Claude Code](https://claude.com/claude-code)